### PR TITLE
feat(skill): merge mybooks_tts skill into mybooks skill

### DIFF
--- a/skills/mybooks/SKILL.md
+++ b/skills/mybooks/SKILL.md
@@ -3,7 +3,7 @@ name: mybooks
 homepage: https://www.mybooks.top
 allowed-tools: Bash(python3:*)
 metadata: {"clawdbot":{},"openclaw":{"requires":{"bins":["python3"],"env":["MYBOOKS_HOST","MYBOOKS_USER","MYBOOKS_PASSWORD"]}}}
-description: "MyBooks(PoxenStudio/Talebook)是个人书库管理系统，提供电子书及实体书管理，包括存储、分类、搜索和元数据管理功能。你可以帮助用户：查询书库统计信息和阅读统计,搜索/浏览书籍,获取书籍详情,更新书籍元数据（书名、作者、标签、分类、简介等）,自动联网填充书籍信息,发送书籍到邮箱或阅读器设备,上传电子书或通过ISBN添加实体书,管理阅读状态（想读/在读/已读/收藏）,查看作者信息和分类信息等"
+description: "MyBooks(PoxenStudio/Talebook)是个人书库管理系统，提供电子书及实体书管理，包括存储、分类、搜索和元数据管理功能。你可以帮助用户：查询书库统计信息和阅读统计,搜索/浏览书籍,获取书籍详情,更新书籍元数据（书名、作者、标签、分类、简介等）,自动联网填充书籍信息,发送书籍到邮箱或阅读器设备,上传电子书或通过ISBN添加实体书,管理阅读状态（想读/在读/已读/收藏）,查看作者信息和分类信息,以及MiMo TTS有声书功能（配置TTS API、EPUB转有声书、查询转换进度、克隆音色与语音提示词管理，需管理员权限）等"
 ---
 
 # MyBooks
@@ -14,6 +14,7 @@ description: "MyBooks(PoxenStudio/Talebook)是个人书库管理系统，提供�
 export MYBOOKS_HOST="http://127.0.0.1:8082"
 export MYBOOKS_USER="admin"
 export MYBOOKS_PASSWORD="your_password"
+export MYBOOKS_SSL_VERIFY="false"   # 如服务器使用自签名证书，设为 false
 
 然后按如下方式执行：
 <skill-installation-path>/scripts/mybooks_api.py <tool-name> '<json-args>'
@@ -42,6 +43,14 @@ export MYBOOKS_PASSWORD="your_password"
 | `"params.invalid"` | 请求参数错误 |
 | `"params.book.invalid"` | 书籍不存在或 ID 错误 |
 | `"task.running"` | 后台任务正在进行中，稍后重试 |
+| `"tts.converting"` | TTS 转换任务正在运行 |
+| `"tts.no_config"` | 未配置 TTS API |
+| `"clone.exists"` | 克隆音色名称已存在 |
+| `"clone.not_found"` | 克隆音色不存在 |
+| `"clone.too_large"` | 文件超过 7MB 限制 |
+| `"clone.invalid_format"` | 仅支持 MP3/WAV 格式 |
+| `"prompt.exists"` | 提示词名称已存在 |
+| `"prompt.not_found"` | 提示词不存在 |
 
 ### 认证方式
 - 脚本通过 `MYBOOKS_USER` / `MYBOOKS_PASSWORD` 环境变量自动调用 `/api/user/sign_in` 完成登录
@@ -669,6 +678,361 @@ export MYBOOKS_PASSWORD="your_password"
 
 ---
 
+## TTS 有声书工具列表（MiMo TTS，需管理员权限）
+
+> 将 EPUB 电子书转换为有声书。所有 TTS 接口均需要**管理员权限**。
+
+### `tts_save_config` — 保存 TTS API 配置
+
+**使用场景**：配置 TTS API 的连接参数（API URL、模型、密钥、类型等），保存后服务端加密存储
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `api_url` | string | ✅ | API 地址，如 `https://api.xiaomimimo.com/v1/chat/completions` |
+| `model_name` | string | ✅ | 模型 ID，MiMo TTS 类型固定为 `mimo-v2.5-tts` |
+| `api_type` | string | ✅ | API 类型：`chat_completions`（MiMo TTS）/ `audio_speech`（OpenAI 兼容）/ `custom` |
+| `api_key` | string | ✅ | API 密钥 |
+| `auth_type` | string | ❌ | 认证类型：`bearer`（默认）/ `basic` / `custom` |
+| `voice_name` | string | ❌ | 预置音色 ID（`api_type=chat_completions` 且 `voiceType=preset` 时）或 `audio_speech` 的音色名 |
+| `voice_desc` | string | ❌ | 自定义音色描述（`voiceType=custom` 时） |
+| `clone_voice` | string | ❌ | 克隆音色名称（`voiceType=clone` 时） |
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_save_config '{"api_url":"https://api.xiaomimimo.com/v1/chat/completions","model_name":"mimo-v2.5-tts","api_type":"chat_completions","api_key":"sk-xxx","voice_name":"mimo_default"}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "配置已保存"
+}
+```
+
+---
+
+### `tts_test_connection` — 测试 API 连接
+
+**使用场景**：使用当前保存的配置发送一次测试请求，验证 API Key 和端点是否可用
+
+**权限**：管理员
+
+**参数**：无（使用已保存的配置）
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_test_connection '{}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "连接成功"
+}
+```
+
+**常见错误**：
+| `err` 值 | 含义 |
+|----------|------|
+| `"tts.no_config"` | 未保存配置，请先调用 `tts_save_config` |
+| `"tts.connection_failed"` | 无法连接到 API 服务器 |
+| `"tts.invalid_key"` | API Key 无效 |
+
+---
+
+### `tts_convert` — 开始 EPUB 转有声书
+
+**使用场景**：将指定 EPUB 电子书转换为有声书，后台逐章合成 WAV 音频
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `book_id` | int | ✅ | 书籍 ID |
+| `api_url` | string | ✅ | API 地址 |
+| `model_name` | string | ✅ | 模型 ID |
+| `api_type` | string | ✅ | API 类型：`chat_completions` / `audio_speech` / `custom` |
+| `api_key` | string | ✅ | API 密钥 |
+| `auth_type` | string | ❌ | 认证类型（默认 `bearer`） |
+| `voice_name` | string | ❌ | 预置音色 ID 或 `audio_speech` 音色名 |
+| `voice_desc` | string | ❌ | 自定义音色描述 |
+| `clone_voice` | string | ❌ | 克隆音色名称 |
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_convert '{"book_id":42,"api_url":"https://api.xiaomimimo.com/v1/chat/completions","model_name":"mimo-v2.5-tts","api_type":"chat_completions","api_key":"sk-xxx","voice_name":"mimo_default"}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "转换任务已启动"
+}
+```
+
+**常见错误**：
+| `err` 值 | 含义 |
+|----------|------|
+| `"params.book.invalid"` | 书籍不存在 |
+| `"tts.converting"` | 已有转换任务在运行 |
+| `"book.no_epub"` | 书籍没有 EPUB 格式 |
+
+---
+
+### `tts_progress` — 查询转换进度
+
+**使用场景**：查询当前 TTS 转换任务的进度、阶段和章节信息
+
+**权限**：管理员
+
+**参数**：无
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_progress '{}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "status": "running",
+  "progress": 35,
+  "stage": "converting",
+  "current_chapter": 7,
+  "total_chapters": 20,
+  "current_title": "第七章 归途",
+  "book_id": 42
+}
+```
+
+**status 值**：
+| 值 | 含义 |
+|----|------|
+| `"idle"` | 无任务运行 |
+| `"running"` | 转换进行中 |
+| `"completed"` | 转换已完成 |
+| `"failed"` | 转换失败 |
+
+---
+
+### `tts_clone_upload` — 上传克隆音色
+
+**使用场景**：上传 MP3/WAV 音频样本作为克隆音色，上传后自动切换到 `mimo-v2.5-tts-voiceclone` 模型
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `voice_name` | string | ✅ | 克隆音色名称（如"旁白"、"男主"） |
+| `file_path` | string | ✅ | 本地音频文件的绝对路径（MP3/WAV，≤7MB） |
+
+**限制**：
+- 格式：仅支持 `.mp3` 和 `.wav`
+- 大小：原始文件 ≤ 7MB（Base64 编码后约 9.3MB，MiMo 官方限制 Base64 ≤ 10MB）
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_clone_upload '{"voice_name":"旁白","file_path":"/path/to/sample.mp3"}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "克隆音色上传成功",
+  "data": { "name": "旁白", "ext": "mp3", "size": 1048576 }
+}
+```
+
+**常见错误**：
+| `err` 值 | 含义 |
+|----------|------|
+| `"clone.exists"` | 音色名称已存在 |
+| `"clone.too_large"` | 文件超过 7MB |
+| `"clone.invalid_format"` | 格式不支持 |
+
+---
+
+### `tts_clone_list` — 克隆音色列表
+
+**使用场景**：获取所有已上传的克隆音色列表
+
+**权限**：管理员
+
+**参数**：无
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_clone_list '{}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "clones": [
+    { "name": "旁白", "ext": "mp3", "size": 1048576 },
+    { "name": "男主", "ext": "wav", "size": 2097152 }
+  ]
+}
+```
+
+---
+
+### `tts_clone_delete` — 删除克隆音色
+
+**使用场景**：删除指定的克隆音色
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `voice_name` | string | ✅ | 要删除的克隆音色名称 |
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_clone_delete '{"voice_name":"旁白"}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "克隆音色已删除"
+}
+```
+
+---
+
+### `tts_clone_audio` — 下载克隆音频
+
+**使用场景**：下载/试听指定的克隆音色原始音频文件（返回二进制 WAV 数据）
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `voice_name` | string | ✅ | 克隆音色名称 |
+| `save_to` | string | ❌ | 保存到本地路径（不传则返回 base64） |
+
+**执行脚本**：
+```bash
+# 保存到文件
+<skill-installation-path>/scripts/mybooks_api.py tts_clone_audio '{"voice_name":"旁白","save_to":"/tmp/clone_preview.wav"}'
+
+# 返回 base64（小文件）
+<skill-installation-path>/scripts/mybooks_api.py tts_clone_audio '{"voice_name":"旁白"}'
+```
+
+**响应示例**（保存到文件）：
+```json
+{
+  "err": "ok",
+  "msg": "音频已保存",
+  "path": "/tmp/clone_preview.wav",
+  "size": 1048576
+}
+```
+
+---
+
+### `tts_prompt_list` — 提示词列表
+
+**使用场景**：获取所有已保存的自定义语音提示词
+
+**权限**：管理员
+
+**参数**：无
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_prompt_list '{}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "prompts": [
+    { "name": "温柔女声", "desc": "温柔细腻的语调，语速偏慢，咬字清晰" },
+    { "name": "沉稳男声", "desc": "沉稳厚重的语调，语速适中偏低" }
+  ]
+}
+```
+
+---
+
+### `tts_prompt_save` — 保存提示词
+
+**使用场景**：将自定义音色描述保存为提示词（同名覆盖），存储于服务端 `voice_prompts.json`
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | ✅ | 提示词名称 |
+| `desc` | string | ✅ | 音色描述（自然语言描述语音特征） |
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_prompt_save '{"name":"温柔女声","desc":"温柔细腻的语调，语速偏慢，咬字清晰，富有亲和力"}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "提示词已保存"
+}
+```
+
+---
+
+### `tts_prompt_delete` — 删除提示词
+
+**使用场景**：删除指定的语音提示词
+
+**权限**：管理员
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | ✅ | 要删除的提示词名称 |
+
+**执行脚本**：
+```bash
+<skill-installation-path>/scripts/mybooks_api.py tts_prompt_delete '{"name":"温柔女声"}'
+```
+
+**响应示例**：
+```json
+{
+  "err": "ok",
+  "msg": "提示词已删除"
+}
+```
+
+---
+
 ## 使用场景决策指南
 
 ```
@@ -723,6 +1087,63 @@ export MYBOOKS_PASSWORD="your_password"
     → categories / list_authors / get_author_books
 ```
 
+### TTS 场景
+
+```
+用户请求
+│
+├─ "配置 TTS API" / "设置 MiMo API Key"
+│   → tts_save_config
+│
+├─ "测试 API 能不能用" / "连接正常吗"
+│   → tts_test_connection
+│
+├─ "把这本书转成有声书" / "开始转换"
+│   → tts_convert（需先有配置或直接传参）
+│
+├─ "转换到哪了" / "进度怎么样"
+│   → tts_progress
+│
+├─ "上传克隆音色" / "我想用自己的声音"
+│   → tts_clone_upload
+│
+├─ "有哪些克隆音色" / "看看上传的音色"
+│   → tts_clone_list
+│
+├─ "删除克隆音色" / "不要这个音色了"
+│   → tts_clone_delete
+│
+├─ "试听克隆音色" / "下载克隆音频"
+│   → tts_clone_audio
+│
+├─ "有哪些提示词" / "保存的音色描述"
+│   → tts_prompt_list
+│
+├─ "保存这个音色描述" / "存一个提示词"
+│   → tts_prompt_save
+│
+└─ "删除提示词" / "不要这个描述了"
+    → tts_prompt_delete
+```
+
+---
+
+## 预置音色参考
+
+MiMo TTS 类型（`api_type=chat_completions`）内置 9 个预置音色：
+
+| ID | 名称 | 语言 | 性别 |
+|----|------|------|------|
+| `mimo_default` | MiMo-默认 | 中文 | 女 |
+| `冰糖` | 冰糖 | 中文 | 女 |
+| `茉莉` | 茉莉 | 中文 | 女 |
+| `苏打` | 苏打 | 中文 | 男 |
+| `白桦` | 白桦 | 中文 | 男 |
+| `Mia` | Mia | 英文 | 女 |
+| `Chloe` | Chloe | 英文 | 女 |
+| `Milo` | Milo | 英文 | 男 |
+| `Dean` | Dean | 英文 | 男 |
+
 ---
 
 ## 错误处理规范
@@ -737,6 +1158,11 @@ export MYBOOKS_PASSWORD="your_password"
 | `"book.notfound"` | ISBN 对应的书籍未在网上找到 | 换其他数据源或手动添加 |
 | `"connection.failed"` | 无法连接到设备 | 检查设备 IP 和 WiFi 接收功能是否开启 |
 | `"format.not_supported"` | 书籍没有 epub/azw3/pdf 格式 | 提示用户该书无法同步元数据到文件 |
+| `"tts.converting"` | TTS 转换任务进行中 | 等待完成后重试 |
+| `"tts.no_config"` | 未配置 TTS API | 先调用 `tts_save_config` |
+| `"clone.too_large"` | 克隆音色文件超限 | 提示用户裁剪音频至 7MB 内 |
+| `"clone.invalid_format"` | 克隆音色格式不支持 | 仅支持 MP3/WAV |
+| `"clone.exists"` | 克隆音色名称重复 | 换名或先删除旧的 |
 
 ---
 
@@ -749,3 +1175,11 @@ export MYBOOKS_PASSWORD="your_password"
 5. **send_to_device 限制**：仅支持本地临时推送，不支持通过服务器中转到远程设备。
 6. **在线数据源**：`book_fill` 依赖豆瓣（douban）、百科（baike）等在线源，网络不可用或书籍较冷门时可能无结果。
 7. **批量 book_fill**：建议每批不超过 10 本，避免触发后台任务冲突（`task.running` 错误）。
+8. **TTS 管理员权限**：所有 TTS 接口均需要管理员权限，普通用户无法使用。
+9. **TTS 异步转换**：`tts_convert` 启动后台任务后立即返回，需用 `tts_progress` 轮询进度。
+10. **TTS 断点续传**：重复转换同一本书时，自动跳过已存在的 WAV 文件（≥44 字节），中断后可继续。
+11. **TTS 音频输出**：转换完成后，音频输出到 `/audio/{book_id}` 页面播放，也可通过 Web 界面访问。
+12. **TTS 克隆音色限制**：MP3/WAV ≤ 7MB；上传后自动切换 `mimo-v2.5-tts-voiceclone` 模型。
+13. **TTS 提示词存储**：提示词保存在服务端 `voice_prompts.json`，跨浏览器共享，不依赖本地存储。
+14. **TTS API Key 加密**：API Key 经 PBKDF2-SHA256 + 流加密保存，密钥文件权限 0o600。
+15. **TTS 模型锁定**：MiMo TTS 类型下模型 ID 固定为 `mimo-v2.5-tts`，不可修改；`audio_speech` 和 `custom` 类型可自由修改。

--- a/skills/mybooks/scripts/mybooks_api.py
+++ b/skills/mybooks/scripts/mybooks_api.py
@@ -10,18 +10,26 @@ Environment Variables:
     MYBOOKS_HOST       Server URL with port (e.g., http://192.168.1.2:8082)
     MYBOOKS_USER       Login username
     MYBOOKS_PASSWORD   Login password
+    MYBOOKS_SSL_VERIFY Set to "false" to skip SSL certificate verification (self-signed certs)
 
 Authentication:
     Automatically signs in via /api/user/sign_in before each tool invocation.
     Session cookies (user_id, lt) are maintained throughout the script lifecycle.
     If err=user.need_login is received, the script re-authenticates once and retries.
+
+TTS API Prefix:
+    /api/toolbox/mimo_tts/
 """
 
 import json
 import os
 import sys
+import base64
 import urllib.parse
+import urllib3
 from typing import Any, Dict
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 # ============================================================================
@@ -29,6 +37,8 @@ from typing import Any, Dict
 # ============================================================================
 
 REQUIRED_ENV_VARS = ["MYBOOKS_HOST", "MYBOOKS_USER", "MYBOOKS_PASSWORD"]
+
+API_TTS_PREFIX = "/api/toolbox/mimo_tts"
 
 ERROR_MESSAGES = {
     "env_missing": {
@@ -67,6 +77,7 @@ class MyBooksAPI:
         try:
             import requests
             self.requests = requests
+            self.verify_ssl = os.environ.get("MYBOOKS_SSL_VERIFY", "true").lower() in ("true", "1", "yes")
         except ImportError:
             self._print_error("Python 'requests' library is required. Install with: pip3 install requests")
             sys.exit(1)
@@ -86,7 +97,8 @@ class MyBooksAPI:
                 url,
                 data=data,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=30
+                timeout=30,
+                verify=self.verify_ssl
             )
             resp.raise_for_status()
             result = resp.json()
@@ -117,6 +129,7 @@ class MyBooksAPI:
         url = f"{self.host}{path}"
         kwargs.setdefault('cookies', self.session_cookies)
         kwargs.setdefault('timeout', 30)
+        kwargs.setdefault('verify', self.verify_ssl)
 
         try:
             resp = self.requests.request(method, url, **kwargs)
@@ -495,6 +508,258 @@ class MyBooksAPI:
         return self._call_with_auto_relogin("GET", "/api/read-done")
 
     # ========================================================================
+    # TTS Tool Methods (MiMo TTS audiobook, admin only)
+    # ========================================================================
+
+    def tts_save_config(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Save TTS API configuration (encrypted server-side).
+
+        Args:
+            api_url (str, required): API endpoint URL
+            model_name (str, required): Model ID (e.g., mimo-v2.5-tts)
+            api_type (str, required): chat_completions / audio_speech / custom
+            api_key (str, required): API key
+            auth_type (str, optional): bearer / basic / custom (default: bearer)
+            voice_name (str, optional): Preset voice ID or audio_speech voice
+            voice_desc (str, optional): Custom voice description
+            clone_voice (str, optional): Clone voice name
+        """
+        required = ["api_url", "model_name", "api_type", "api_key"]
+        for field in required:
+            if not args.get(field):
+                return {"status": "error", "message": f"{field} is required"}
+
+        body = {k: v for k, v in args.items() if v is not None}
+        return self._call_with_auto_relogin(
+            "POST",
+            f"{API_TTS_PREFIX}/config",
+            json=body,
+        )
+
+    def tts_test_connection(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Test API connection using saved configuration.
+
+        Args: none
+        """
+        return self._call_with_auto_relogin("POST", f"{API_TTS_PREFIX}/test")
+
+    def tts_convert(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Start EPUB-to-audiobook conversion (async background task).
+
+        Args:
+            book_id (int, required): Book ID
+            api_url (str, required): API endpoint URL
+            model_name (str, required): Model ID
+            api_type (str, required): chat_completions / audio_speech / custom
+            api_key (str, required): API key
+            auth_type (str, optional): bearer / basic / custom
+            voice_name (str, optional): Preset voice ID or audio_speech voice
+            voice_desc (str, optional): Custom voice description
+            clone_voice (str, optional): Clone voice name
+        """
+        required = ["book_id", "api_url", "model_name", "api_type", "api_key"]
+        for field in required:
+            if not args.get(field):
+                return {"status": "error", "message": f"{field} is required"}
+
+        body = {k: v for k, v in args.items() if v is not None}
+        return self._call_with_auto_relogin(
+            "POST",
+            f"{API_TTS_PREFIX}/convert",
+            json=body,
+        )
+
+    def tts_progress(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Query current TTS conversion progress.
+
+        Args: none
+        """
+        return self._call_with_auto_relogin("GET", f"{API_TTS_PREFIX}/progress")
+
+    def tts_clone_upload(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Upload a clone voice sample (MP3/WAV, <=7MB).
+
+        Args:
+            voice_name (str, required): Clone voice name
+            file_path (str, required): Absolute path to local audio file
+        """
+        voice_name = args.get("voice_name", "")
+        file_path = args.get("file_path", "")
+
+        if not voice_name:
+            return {"status": "error", "message": "voice_name is required"}
+        if not file_path:
+            return {"status": "error", "message": "file_path is required"}
+
+        if not os.path.isfile(file_path):
+            return {"status": "error", "message": f"File not found: {file_path}"}
+
+        # Validate format
+        ext = os.path.splitext(file_path)[1].lower().lstrip('.')
+        if ext not in ('mp3', 'wav'):
+            return {"status": "error", "message": "Only MP3 and WAV formats are supported"}
+
+        # Validate size (7MB limit)
+        file_size = os.path.getsize(file_path)
+        if file_size > 7 * 1024 * 1024:
+            return {"status": "error", "message": f"File too large: {file_size} bytes (max 7MB)"}
+
+        try:
+            with open(file_path, 'rb') as f:
+                files = {'file': f}
+                data = {'voice_name': voice_name}
+                return self._call_with_auto_relogin(
+                    "POST",
+                    f"{API_TTS_PREFIX}/clone/upload",
+                    data=data,
+                    files=files,
+                )
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def tts_clone_list(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        List all uploaded clone voices.
+
+        Args: none
+        """
+        return self._call_with_auto_relogin("GET", f"{API_TTS_PREFIX}/clone/list")
+
+    def tts_clone_delete(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Delete a clone voice by name.
+
+        Args:
+            voice_name (str, required): Clone voice name to delete
+        """
+        voice_name = args.get("voice_name", "")
+        if not voice_name:
+            return {"status": "error", "message": "voice_name is required"}
+
+        return self._call_with_auto_relogin(
+            "POST",
+            f"{API_TTS_PREFIX}/clone/delete",
+            json={"voice_name": voice_name},
+        )
+
+    def tts_clone_audio(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Download/preview a clone voice audio file (binary WAV).
+
+        Args:
+            voice_name (str, required): Clone voice name
+            save_to (str, optional): Local path to save the audio;
+                                     if omitted, returns base64-encoded audio
+        """
+        voice_name = args.get("voice_name", "")
+        if not voice_name:
+            return {"status": "error", "message": "voice_name is required"}
+
+        save_to = args.get("save_to", "")
+        query = urllib.parse.urlencode({"voice_name": voice_name})
+
+        url = f"{self.host}{API_TTS_PREFIX}/clone/audio?{query}"
+        kwargs = {
+            'cookies': self.session_cookies,
+            'timeout': 60,
+            'verify': self.verify_ssl,
+        }
+
+        try:
+            resp = self.requests.get(url, **kwargs)
+
+            # Check for auth redirect
+            try:
+                ct = resp.headers.get('Content-Type', '')
+                if 'json' in ct:
+                    result = resp.json()
+                    if result.get("err") == "user.need_login":
+                        self.sign_in()
+                        kwargs['cookies'] = self.session_cookies
+                        resp = self.requests.get(url, **kwargs)
+                        ct = resp.headers.get('Content-Type', '')
+                        if 'json' in ct:
+                            return resp.json()
+            except Exception:
+                pass
+
+            content = resp.content
+
+            if save_to:
+                with open(save_to, 'wb') as f:
+                    f.write(content)
+                return {
+                    "err": "ok",
+                    "msg": "Audio saved",
+                    "path": save_to,
+                    "size": len(content),
+                }
+            else:
+                # Return base64 for small files
+                b64 = base64.b64encode(content).decode('ascii')
+                return {
+                    "err": "ok",
+                    "msg": "Audio retrieved",
+                    "voice_name": voice_name,
+                    "size": len(content),
+                    "base64": b64,
+                }
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def tts_prompt_list(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        List all saved voice prompt descriptions.
+
+        Args: none
+        """
+        return self._call_with_auto_relogin("GET", f"{API_TTS_PREFIX}/prompt/list")
+
+    def tts_prompt_save(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Save a voice prompt description (same name overwrites).
+
+        Args:
+            name (str, required): Prompt name
+            desc (str, required): Voice description text
+        """
+        name = args.get("name", "")
+        desc = args.get("desc", "")
+
+        if not name:
+            return {"status": "error", "message": "name is required"}
+        if not desc:
+            return {"status": "error", "message": "desc is required"}
+
+        return self._call_with_auto_relogin(
+            "POST",
+            f"{API_TTS_PREFIX}/prompt/save",
+            json={"name": name, "desc": desc},
+        )
+
+    def tts_prompt_delete(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Delete a voice prompt by name.
+
+        Args:
+            name (str, required): Prompt name to delete
+        """
+        name = args.get("name", "")
+        if not name:
+            return {"status": "error", "message": "name is required"}
+
+        return self._call_with_auto_relogin(
+            "POST",
+            f"{API_TTS_PREFIX}/prompt/delete",
+            json={"name": name},
+        )
+
+    # ========================================================================
     # Tool Dispatcher
     # ========================================================================
 
@@ -519,7 +784,10 @@ class MyBooksAPI:
                 "list_authors", "get_author_books", "book_upload",
                 "book_add_by_isbn", "wants", "list_wants", "favorite",
                 "list_favorites", "reading", "list_reading", "read_done",
-                "list_read_done"
+                "list_read_done", "tts_save_config", "tts_test_connection",
+                "tts_convert", "tts_progress", "tts_clone_upload", "tts_clone_list",
+                "tts_clone_delete", "tts_clone_audio", "tts_prompt_list",
+                "tts_prompt_save", "tts_prompt_delete"
             ]
             return {
                 "status": "error",


### PR DESCRIPTION
## 概述

将独立的 mybooks_tts skill（MiMo TTS 有声书工具）合并进主 mybooks skill，统一为单个 skill、单一脚本。

## 变更内容

**skills/mybooks/scripts/mybooks_api.py**
- 新增 11 个 TTS 工具：tts_save_config / tts_test_connection / tts_convert / tts_progress / tts_clone_upload / tts_clone_list / tts_clone_delete / tts_clone_audio / tts_prompt_list / tts_prompt_save / tts_prompt_delete
- 支持 MYBOOKS_SSL_VERIFY 环境变量（自签名证书时跳过 SSL 校验），sign_in / _call_api 统一透传

**skills/mybooks/SKILL.md**
- 新增 TTS 有声书工具列表章节（含参数表、示例、常见错误）
- 常见错误码表、错误处理规范补充 tts.* / clone.* / prompt.* 错误码
- 使用场景决策指南新增 TTS 场景分支
- 新增预置音色参考表（MiMo 9 个预置音色）
- 注意事项补充 TTS 相关 8 条说明（管理员权限、异步转换、断点续传、克隆音色限制、提示词存储、API Key 加密、模型锁定等）

## 背景

原独立仓库：https://github.com/shiningsprk-arch/mybooks-tts-skill（合并后保留，内容与本次提交一致）
