### PR TITLE
fix(toolbox): 繁简转换补全元数据转换（简介/出版社/丛书/标签）并修复备份崩溃

### DIFF
--- a/webserver/toolbox/chinese_converter_tool.py
+++ b/webserver/toolbox/chinese_converter_tool.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import threading
+import time
 import traceback
 from typing import Optional
 
@@ -253,6 +254,17 @@ class ChineseConverterTool(BaseTool):
         if convert_title and mi.authors:
             mi.authors = [engine.convert(a) for a in mi.authors]
             mi.author_sort = None  # 名字已转换，排序键由 calibre 按新名字重算
+        if convert_title:
+            # 简介/出版社/丛书/标签同步转换（简介可能含 HTML：opencc 逐字符
+            # 转换，标签与实体为 ASCII 不受影响）
+            if mi.comments:
+                mi.comments = engine.convert(mi.comments)
+            if mi.publisher:
+                mi.publisher = engine.convert(mi.publisher)
+            if mi.series:
+                mi.series = engine.convert(mi.series)
+            if mi.tags:
+                mi.tags = [engine.convert(t) for t in mi.tags]
         mi.languages = [DIRECTION_LANG.get(direction, "zh")]
         mi.uuid = None  # 新书应使用独立 UUID，避免与原书冲突
 
@@ -310,6 +322,16 @@ class ChineseConverterTool(BaseTool):
             if mi.authors:
                 mi.authors = [engine.convert(a) for a in mi.authors]
                 mi.author_sort = None  # 名字已转换，排序键由 calibre 按新名字重算
+            # 简介/出版社/丛书/标签同步转换（简介可能含 HTML：opencc 逐字符
+            # 转换，标签与实体为 ASCII 不受影响）
+            if mi.comments:
+                mi.comments = engine.convert(mi.comments)
+            if mi.publisher:
+                mi.publisher = engine.convert(mi.publisher)
+            if mi.series:
+                mi.series = engine.convert(mi.series)
+            if mi.tags:
+                mi.tags = [engine.convert(t) for t in mi.tags]
             mi.languages = [DIRECTION_LANG.get(direction, "zh")]
             self.db.set_metadata(book_id, mi, force_changes=True)
             logging.info("[ChineseConverterTool] Updated title/authors/language for book_id=%d", book_id)


### PR DESCRIPTION
## 概述

修复繁简转换工具的元数据转换遗漏：转换图书时简介、出版社、丛书、标签未随书名一起转换（用户看到书库详情页的简介/出版社仍是转换前的简体/繁体）。同时修复一个备份模式的隐藏崩溃 bug。

## 根因

- 库内元数据更新路径只处理 `title`/`authors`：`_import_as_new_book`（另存为新书）与 `_apply_title_conversion`（替换模式）均未对 `comments`（简介）/`publisher`（出版社）/`series`（丛书）/`tags`（标签）调用转换引擎，直接继承原值。
- EPUB 文件内容层（OPF/NCX）不受影响——`epub_converter._convert_xml_doc` 本就转换全部文本节点，漏的是 Calibre 库内元数据层。

## 改动（chinese_converter_tool.py，+22 行）

1. `_import_as_new_book`：`convert_title=True` 时同步转换 `comments` / `publisher` / `series` / `tags`（均判空防 None）
2. `_apply_title_conversion`（替换模式）：同上补齐
3. 顺手修复原有 bug：`_replace_format` 使用了 `time.time()` 但文件从未 `import time`——`backup=True` 的替换模式此前必抛 `NameError`

## 验证

- 引擎转换含 HTML 的简介安全（`<p>…“盗墓”…</p>` 标签/引号/实体保持，正文转繁体）
- 出版社/丛书/标签转换正确（上海文艺出版社 → 上海文藝出版社 等）
- flake8 零问题；encoding_detect 53 单测无回归

## 行为说明

- 简介/出版社转换跟随现有"转换书名等元数据"开关（`convert_title`），不新增独立开关
- `convert_title=False` 时行为与之前完全一致（元数据原样保留）
