### PR TITLE
fix(toolbox): 格式合并移动端搜索——回车跳焦点导致来源书籍无法搜索

### DIFF
--- a/app/src/pages/toolbox/merge_formats_tool.vue
+++ b/app/src/pages/toolbox/merge_formats_tool.vue
@@ -30,7 +30,9 @@
             hide-details
             class="mb-3"
             prepend-inner-icon="mdi-magnify"
-            @keyup.enter="searchLeft"
+            append-outer-icon="mdi-magnify"
+            @keydown.enter.prevent="onEnterLeft"
+            @click:append-outer="searchLeft"
             @click:clear="clearLeft"
           />
           <div class="mft-book-list">
@@ -93,7 +95,9 @@
             hide-details
             class="mb-3"
             prepend-inner-icon="mdi-magnify"
-            @keyup.enter="searchRight"
+            append-outer-icon="mdi-magnify"
+            @keydown.enter.prevent="onEnterRight"
+            @click:append-outer="searchRight"
             @click:clear="clearRight"
           />
           <div class="mft-book-list">
@@ -225,6 +229,16 @@ export default {
     this.$store.commit('navbar', true);
   },
   methods: {
+    // 移动端 IME 组合输入时 Enter 仅确认候选词（isComposing），不得触发搜索；
+    // keydown.enter.prevent 同时尽量阻止虚拟键盘"next"键把焦点跳到下一个输入框
+    onEnterLeft(e) {
+      if (e && e.isComposing) return;
+      this.searchLeft();
+    },
+    onEnterRight(e) {
+      if (e && e.isComposing) return;
+      this.searchRight();
+    },
     async searchLeft() {
       const q = (this.leftQuery || '').trim();
       if (!q) return;


### PR DESCRIPTION
## 概述

修复格式合并工具移动端搜索交互缺陷：手机上输入完来源书籍关键词后按回车，焦点会跳到目标书籍输入框，导致来源书籍无法搜索选择。

## 根因

- 搜索仅绑定 `@keyup.enter`，页面无任何搜索按钮
- 两个 `v-text-field` 并排渲染为两个 `<input>`，移动端虚拟键盘的 Enter 是"next"语义——浏览器原生将焦点移到下一个输入框（目标书籍框），即"回车跳转"
- 移动端 IME 下 Enter 的 keyup 常带 `isComposing`/`keyCode 229`（中文输入法组词确认），`@keyup.enter` 处理器不执行或拿到不完整关键词 → 焦点跑了、列表没出结果

## 改动（merge_formats_tool.vue，+16/-2）

1. **主修复**：两个搜索输入框加 `append-outer-icon="mdi-magnify"` + `@click:append-outer` 搜索按钮——移动端点按钮即可搜索，不依赖回车（`clearable` 占用 append 位，故按钮用 append-outer）
2. **辅助修复**：`@keyup.enter` 改为 `@keydown.enter.prevent` + `isComposing` 检查——IME 组词确认回车不误触发搜索，并尽量阻止"next"键焦点跳转
3. 桌面端行为不变（回车搜索、清除、选择、合并流程均未动）

## 验证

- 桌面回归：回车/按钮搜索、清除、选择合并流程逻辑未变
- 移动端需真机验证：输入关键词 → 点放大镜按钮 → 列表出结果
