### PR TITLE
fix: search_best_book 恢复 mi 参数，修复自动刮削 TypeError (#55)

### DIFF
--- a/webserver/services/book_search.py
+++ b/webserver/services/book_search.py
@@ -118,7 +118,7 @@ class BookSearch:
         return books
 
     @staticmethod
-    def search_best_book():
+    def search_best_book(mi):
         """
         按信息源优先级顺序逐个查询，返回第一个可用的最佳匹配（找到即停止，不再查询后续信息源）
 


### PR DESCRIPTION
### 问题

自动刮削（导入书籍/批量更新元数据）时所有书籍均失败，日志报：

ERROR:root:获取书籍信息失败 id=727: BookSearch.search_best_book() takes 0 positional arguments but 1 was given

对应 Issue #55。

### 根因

commit 9ea604b0（"当douban刮削失败明显显示出错误信息"）误删了 BookSearch.search_best_book 的 mi 参数（签名变为 0 参数），但方法体内仍使用 mi（mi.title、mi.deepcopy()），调用方 webserver/services/autofill.py 也仍以 BookSearch.search_best_book(mi) 传参调用，导致 TypeError，自动刮削 100% 失败。

### 修改

webserver/services/book_search.py 一行：

`diff
-    def search_best_book():
+    def search_best_book(mi):
`

Fixes #55