### PR TITLE
有声书：新增字幕播放功能；音频链接改相对路径修复反代下无法播放

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1137,6 +1137,7 @@
     "playlist": "Playlist",
     "chapters": "chapters",
     "noAudioFiles": "No audio files available",
+    "subtitle": "Subtitle (click to seek)",
     "currentChapter": "Current Chapter",
     "startFromBeginning": "Start From Beginning",
     "timer": "Timer",

--- a/app/locales/zh-TW.json
+++ b/app/locales/zh-TW.json
@@ -1136,6 +1136,7 @@
     "playlist": "播放清單",
     "chapters": "章節",
     "noAudioFiles": "暫無音訊檔案",
+    "subtitle": "字幕（點擊跳轉）",
     "currentChapter": "當前章節",
     "startFromBeginning": "重新開始",
     "timer": "定時",

--- a/app/locales/zh.json
+++ b/app/locales/zh.json
@@ -1138,6 +1138,7 @@
     "playlist": "播放列表",
     "chapters": "章节",
     "noAudioFiles": "暂无音频文件",
+    "subtitle": "字幕（点击跳转）",
     "currentChapter": "当前章节",
     "startFromBeginning": "重新开始",
     "timer": "定时",

--- a/app/src/pages/audio/_id.vue
+++ b/app/src/pages/audio/_id.vue
@@ -130,6 +130,15 @@
         ></v-slider>
       </div>
 
+      <!-- 字幕显示区 -->
+      <div class="subtitle-section" v-if="showSubtitle && subtitleCues.length">
+        <div
+          class="subtitle-text"
+          @click="currentCue && seekToCue(currentCue)"
+          :title="$t('audio.subtitle')"
+        >{{ currentCue ? currentCue.text : ' ' }}</div>
+      </div>
+
       <!-- 控制按钮 -->
       <div class="controls-section">
         <div class="main-controls">
@@ -168,6 +177,18 @@
         </div>
 
         <div class="secondary-controls">
+          <!-- 字幕开关 -->
+          <v-btn
+            v-if="subtitleCues.length > 0"
+            icon
+            large
+            @click="toggleSubtitle"
+            class="subtitle-btn"
+            :color="showSubtitle ? 'primary' : ''"
+          >
+            <v-icon>{{ showSubtitle ? 'mdi-subtitles' : 'mdi-subtitles-outline' }}</v-icon>
+          </v-btn>
+
           <!-- 倍速控制 -->
           <v-menu offset-y>
             <template v-slot:activator="{ on, attrs }">
@@ -362,6 +383,12 @@ export default {
       playbackRate: 1,
       playbackRates: [0.5, 1, 1.25, 1.5, 2],
 
+      // 字幕相关
+      subtitleCues: [],
+      currentCueIndex: -1,
+      showSubtitle: true,
+      subtitleCache: {},
+
       // 定时器
       sleepTimer: null,
       sleepTimerInterval: null,
@@ -398,6 +425,13 @@ export default {
       return this.audioFiles[this.currentTrackIndex];
     },
 
+    currentCue() {
+      if (this.currentCueIndex >= 0 && this.currentCueIndex < this.subtitleCues.length) {
+        return this.subtitleCues[this.currentCueIndex];
+      }
+      return null;
+    },
+
     shouldShowAuthors() {
       // 如果作者信息不存在，隐藏
       if (!this.book.authors) {
@@ -414,6 +448,7 @@ export default {
   },
 
   mounted() {
+    this.restoreSubtitlePreference();
     this.initializePlayer();
     this.restorePlaybackPosition();
     this.startProgressSaving();
@@ -446,6 +481,7 @@ export default {
       if (index >= 0 && index < this.audioFiles.length) {
         this.currentTrackIndex = index;
         const audio = this.audioFiles[index];
+        this.loadSubtitle(audio.subtitle);
         const player = this.$refs.audioPlayer;
         if (!player) return;
 
@@ -616,6 +652,8 @@ export default {
         if (this.duration > 0) {
           this.progress = (this.currentTime / this.duration) * 100;
         }
+
+        this.syncSubtitle();
       }
     },
 
@@ -645,6 +683,110 @@ export default {
 
     onPause() {
       this.isPlaying = false;
+    },
+
+    // 字幕方法
+    parseSRT(content) {
+      const cues = [];
+      // 兼容 SRT 的 HH:MM:SS,mmm 与 WebVTT 省略小时的 MM:SS.mmm
+      const timeRe = /(?:(\d{1,2}):)?(\d{1,2}):(\d{2})[,.](\d{1,3})\s*-->\s*(?:(\d{1,2}):)?(\d{1,2}):(\d{2})[,.](\d{1,3})/;
+      const blocks = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim().split(/\n\n+/);
+      for (const block of blocks) {
+        const lines = block.split('\n');
+        const timeLineIdx = lines.findIndex(l => timeRe.test(l));
+        if (timeLineIdx === -1) continue;
+        const m = lines[timeLineIdx].match(timeRe);
+        const start = (+(m[1] || 0)) * 3600 + (+m[2]) * 60 + (+m[3]) + (+m[4].padEnd(3, '0')) / 1000;
+        const end = (+(m[5] || 0)) * 3600 + (+m[6]) * 60 + (+m[7]) + (+m[8].padEnd(3, '0')) / 1000;
+        const text = lines.slice(timeLineIdx + 1).join('\n').trim();
+        if (text && end > start) {
+          cues.push({ start, end, text });
+        }
+      }
+      // 防御畸形文件：保证二分查找前提（按开始时间有序）
+      cues.sort((a, b) => a.start - b.start);
+      return cues;
+    },
+
+    async loadSubtitle(url) {
+      this.subtitleCues = [];
+      this.currentCueIndex = -1;
+      if (!url || !process.client) return;
+
+      if (this.subtitleCache[url]) {
+        this.subtitleCues = this.subtitleCache[url];
+        return;
+      }
+
+      try {
+        const resp = await fetch(url, { credentials: 'include' });
+        if (!resp.ok) return;
+        const content = await resp.text();
+        const cues = this.parseSRT(content);
+        this.subtitleCache[url] = cues;
+        // 防止快速切轨时旧请求覆盖新字幕
+        const currentAudio = this.currentAudio;
+        if (currentAudio && currentAudio.subtitle === url) {
+          this.subtitleCues = cues;
+        }
+      } catch (error) {
+        console.error('Failed to load subtitle:', error);
+      }
+    },
+
+    syncSubtitle() {
+      if (!this.subtitleCues.length) return;
+      // 使用播放器绝对时间：普通分章文件与 currentTime 一致；
+      // m4b 内嵌章节共享整条音轨的外挂字幕时，字幕时间轴为绝对时间
+      const player = this.$refs.audioPlayer;
+      const t = player ? player.currentTime : this.currentTime;
+      let lo = 0;
+      let hi = this.subtitleCues.length - 1;
+      let idx = -1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const c = this.subtitleCues[mid];
+        if (t < c.start) {
+          hi = mid - 1;
+        } else if (t >= c.end) {
+          lo = mid + 1;
+        } else {
+          idx = mid;
+          break;
+        }
+      }
+      if (idx !== this.currentCueIndex) {
+        this.currentCueIndex = idx;
+      }
+    },
+
+    seekToCue(cue) {
+      if (!cue || !this.$refs.audioPlayer) return;
+      // 字幕时间为音轨绝对时间，直接设置即可（分章文件两者等价）
+      this.$refs.audioPlayer.currentTime = cue.start;
+    },
+
+    toggleSubtitle() {
+      this.showSubtitle = !this.showSubtitle;
+      if (process.client) {
+        try {
+          localStorage.setItem('audio_subtitle_enabled', this.showSubtitle ? '1' : '0');
+        } catch (error) {
+          console.error('Error saving subtitle preference:', error);
+        }
+      }
+    },
+
+    restoreSubtitlePreference() {
+      if (!process.client) return;
+      try {
+        const saved = localStorage.getItem('audio_subtitle_enabled');
+        if (saved !== null) {
+          this.showSubtitle = saved === '1';
+        }
+      } catch (error) {
+        console.error('Error restoring subtitle preference:', error);
+      }
     },
 
     // 工具方法
@@ -1206,6 +1348,36 @@ export default {
   margin: 0;
 }
 
+/* 字幕显示区 */
+.subtitle-section {
+  min-height: 44px;
+  max-height: 72px;
+  overflow-y: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 16px;
+}
+
+.subtitle-text {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #e0e0e0;
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: 8px;
+  padding: 6px 14px;
+  text-align: center;
+  white-space: pre-wrap;
+  word-break: break-word;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  max-width: 100%;
+}
+
+.subtitle-text:hover {
+  background: rgba(156, 39, 176, 0.35);
+}
+
 .controls-section {
   flex: 1;
   display: flex;
@@ -1249,7 +1421,8 @@ export default {
 }
 
 .speed-btn,
-.timer-btn {
+.timer-btn,
+.subtitle-btn {
   background-color: #404040 !important;
   color: white !important;
   position: relative;
@@ -1296,6 +1469,17 @@ export default {
     flex-direction: column;
     height: 50%;
     padding: 10px;
+  }
+
+  .subtitle-section {
+    min-height: 36px;
+    max-height: 56px;
+    padding: 2px 8px;
+  }
+
+  .subtitle-text {
+    font-size: 0.875rem;
+    padding: 4px 10px;
   }
 
   .cover-section {

--- a/webserver/constants.py
+++ b/webserver/constants.py
@@ -17,6 +17,8 @@ CUSTOM_COVER_IMAGE = "/data/books/logo/default_cover.jpg"
 CALIBRE_ERROR_FLAG = "<*ERROR*>"
 SUPPORTED_EBOOK_FORMATS = ["azw3", "epub", "mobi", "pdf", "txt", "azw", "docx"]
 SUPPORTED_AUDIO_FORMATS = ['.mp3', ".m4a", ".m4b", ".wav", ".wma", ".opus"]
+# 有声书字幕文件格式（与音频文件同目录同名，如 0001_第一章.wav -> 0001_第一章.srt）
+SUPPORTED_SUBTITLE_FORMATS = ['.srt', '.vtt']
 
 COLUMN_CATEGORY = "category"
 CALIBRE_COLUMN_CATEGORY = "#category"

--- a/webserver/handlers/audio.py
+++ b/webserver/handlers/audio.py
@@ -23,7 +23,7 @@ from webserver.base.formatter import BookFormatter
 from webserver.handlers.base import BaseHandler, auth, js, is_admin
 from webserver.models import BizKey, ReaderPaidBook, ReaderLog, Message
 from webserver.worker.epub2audio_worker import EpubToAudioWorker
-from webserver.constants import ENABLE_VIP_QUOTA_KEY, SUPPORTED_AUDIO_FORMATS
+from webserver.constants import ENABLE_VIP_QUOTA_KEY, SUPPORTED_AUDIO_FORMATS, SUPPORTED_SUBTITLE_FORMATS
 from webserver.services.background_service import BackgroundService, BackgroundTask
 
 
@@ -197,7 +197,7 @@ class AudioUtils:
             file_urls.append(
                 {
                     "filename": os.path.splitext(file)[0],
-                    "url": f"{AudioUtils.site_url}/api/audio/{book_id}/{file}",
+                    "url": f"/api/audio/{book_id}/{file}",
                     "size": file_size,
                 }
             )
@@ -258,7 +258,7 @@ class AudioDetail(BaseHandler):
                 chapter_urls.append(
                     {
                         "filename": title,
-                        "url": f"{self.site_url}/api/audio/{book_id}/{file}",
+                        "url": f"/api/audio/{book_id}/{file}",
                         "size": chapter_size,
                         "start_time": start,
                         "end_time": end
@@ -305,6 +305,13 @@ class AudioDetail(BaseHandler):
                             is_paid = True
 
                     # Generate download URLs for audio files
+                    # 扫描同目录下的字幕文件（与音频同名，如 0001_第一章.wav -> 0001_第一章.srt）
+                    subtitle_map = {}
+                    for sub in sorted(os.listdir(audio_dir)):
+                        stem, ext = os.path.splitext(sub)
+                        if ext.lower() in SUPPORTED_SUBTITLE_FORMATS and stem not in subtitle_map:
+                            subtitle_map[stem] = sub
+
                     file_urls = []
                     for file in sorted(audio_files, key=natural_sort_key):
                         if file.find(SKIP_AUDIO_FILE_PREFIX) > 0:
@@ -316,16 +323,23 @@ class AudioDetail(BaseHandler):
                         if file.lower().endswith('.m4b'):
                             chapter_urls = self._extract_m4b_chapters(file_path, file_size, book_id, file)
                             if chapter_urls:
+                                # m4b 内嵌章节共享同一个外部字幕文件
+                                sub_file = subtitle_map.get(os.path.splitext(file)[0])
+                                for chapter_url in chapter_urls:
+                                    if sub_file:
+                                        chapter_url["subtitle"] = f"/api/audio/{book_id}/{sub_file}"
                                 file_urls.extend(chapter_urls)
                                 continue  # Skip adding the whole m4b file
 
-                        file_urls.append(
-                            {
-                                "filename": os.path.splitext(file)[0],
-                                "url": f"{self.site_url}/api/audio/{book_id}/{file}",
-                                "size": file_size,
-                            }
-                        )
+                        audio_item = {
+                            "filename": os.path.splitext(file)[0],
+                            "url": f"/api/audio/{book_id}/{file}",
+                            "size": file_size,
+                        }
+                        sub_file = subtitle_map.get(audio_item["filename"])
+                        if sub_file:
+                            audio_item["subtitle"] = f"/api/audio/{book_id}/{sub_file}"
+                        file_urls.append(audio_item)
                     return {
                         "err": "ok",
                         "audio_dir": audio_dir,
@@ -852,6 +866,8 @@ class AudioFile(BaseHandler):
                 ".m4b": "audio/mp4",
                 ".opus": "audio/opus",
                 ".wma": "audio/x-ms-wma",
+                ".srt": "application/x-subrip",
+                ".vtt": "text/vtt",
             }
             self.set_header("Content-Type", content_types.get(ext, "audio/mpeg"))
 
@@ -1004,12 +1020,22 @@ class AudioCollection(BaseHandler):
             # 如果zip不存在，创建它
             if not os.path.exists(zip_path):
                 try:
+                    # 字幕文件一并打包（与音频同名）
+                    subtitle_files = [
+                        f
+                        for f in os.listdir(audio_dir)
+                        if f.lower().endswith(tuple(SUPPORTED_SUBTITLE_FORMATS))
+                    ]
                     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
                         for audio_file in sorted(audio_files, key=natural_sort_key):
                             if audio_file.find(SKIP_AUDIO_FILE_PREFIX) > 0:
                                 continue
                             file_path = os.path.join(audio_dir, audio_file)
                             zipf.write(file_path, audio_file)
+                        for sub_file in sorted(subtitle_files):
+                            sub_path = os.path.join(audio_dir, sub_file)
+                            if os.path.exists(sub_path):
+                                zipf.write(sub_path, sub_file)
                 except Exception as e:
                     logging.error(f"Error creating zip file: {e}")
                     return {"err": "server.error", "msg": _("创建压缩文件失败")}
@@ -1034,7 +1060,7 @@ class AudioCollection(BaseHandler):
             DailyDownloadMap[(user.id, book_id)] = datetime.datetime.now()
 
             # 生成下载链接
-            download_url = f"{self.get_site_url()}/api/audios/{book_id}/collection/download?key={download_key}"
+            download_url = f"/api/audios/{book_id}/collection/download?key={download_key}"
 
             # 保存日志
             db_log.set_extra("result", 0)


### PR DESCRIPTION
﻿# PR 说明：有声书字幕播放功能 + 音频链接相对路径修复

> 目标仓库：PoxenStudio/mybooks　目标分支：`develop`
> 分支：`feat/audio-subtitle`
> 改动文件：`webserver/constants.py`、`webserver/handlers/audio.py`、`app/src/pages/audio/_id.vue`、`app/locales/{zh,zh-TW,en}.json`

---

本 PR 包含两部分：

1. **新功能**：有声书播放页支持外挂字幕（SRT/VTT）加载与显示；
2. **修复**：音频/字幕/下载链接改为相对路径，解决反向代理非标准端口场景下浏览器无法播放的问题。

---

## 一、新功能：有声书字幕播放

### 功能描述

为有声书播放页（`/audio/{book_id}`）增加外挂字幕支持：只要音频文件同目录下存在**同名**字幕文件（如 `0001_第一章.wav` → `0001_第一章.srt`），播放时即自动加载并在进度条上方显示当前台词，支持点击跳转。

### 后端改动（`webserver/`）

| 文件 | 改动 |
|------|------|
| `constants.py` | 新增 `SUPPORTED_SUBTITLE_FORMATS = ['.srt', '.vtt']` |
| `handlers/audio.py` · `AudioDetail.get()` | 扫描音频目录下的同名字幕文件，在返回的音频条目及 m4b 章节条目上附加 `"subtitle": "/api/audio/{id}/{sub_file}"` 字段 |
| `handlers/audio.py` · `AudioFile.get()` | 新增 `.srt`（`application/x-subrip`）、`.vtt`（`text/vtt`）的 MIME 类型，保证浏览器正确解析 |
| `handlers/audio.py` · `AudioCollection` | 合集打包下载时把字幕文件一并写入 zip |

### 前端改动（`app/src/pages/audio/_id.vue`）

- SRT / VTT 解析器，兼容 `HH:MM:SS,mmm`（SRT）与 WebVTT 省略小时等时间格式；
- 字幕随播放实时滚动显示当前 cue，点击字幕跳转到对应时间点；
- 播放控制区新增字幕开关按钮（`mdi-subtitles` 图标），开关状态记忆用户偏好；
- 切换曲目自动切换对应字幕并缓存已解析内容；
- i18n 文案新增 `audio.subtitle`（简体 / 繁体 / 英文）。

### 已知限制

- **暂未实现字幕的自动生成功能**。目前需要用户自行准备与音频同名的 `.srt` / `.vtt` 文件放到音频目录；后续计划配合 TTS 转换流程生成带时间轴的字幕，届时另提 PR。

---

## 二、修复：音频链接改相对路径，解决反代下无法播放

### 问题描述

通过反向代理（如 Nginx Proxy Manager）以**非标准端口**的 HTTPS 地址访问站点时（例如 `https://talebook.example.com:50006/`），有声书页面点击播放后浏览器始终无法加载音频；而直连 `http://IP:端口` 访问一切正常。浏览器控制台可见音频请求发往 `https://域名/api/audio/...`（默认 443 端口）后超时——**实际监听端口被丢失**。

### 根因分析

1. 有声书相关接口返回的音频地址是**绝对 URL**，由后端拼接 `{site_url}/api/audio/{book_id}/{文件名}`；
2. `site_url` 在 `BaseHandler.set_hosts()` 中按 `request.protocol + "://" + host` 生成，`host` 优先取请求头 `X-Forwarded-Host`，缺省回退 `request.host`；
3. 常见反代配置（含 NPM 默认模板）转发时执行 `proxy_set_header Host $host;`——nginx 的 `$host` **不含端口**，且默认不发送 `X-Forwarded-Host`；
4. 于是接口返回形如 `https://域名/api/audio/xxx.wav` 的地址（`:50006` 被剥掉）。前端直接赋给 `<audio>` 或 `new Audio(url)`，浏览器按 443 端口发起请求，而服务实际监听在非标准端口上，请求永远打不到代理，播放即被阻断。

**实测证据**（NPM 访问日志）：页面与 `/api/audio/{id}` 的 JSON 请求均正常到达并返回 200，但所有 `.wav` 文件请求**一条都没有出现在代理日志里**——全部被发往了无人监听的 443 端口。

### 涉及的三条代码路径（均已处理）

| 路径 | 原 URL 构造 | 问题表现 |
|------|-------------|----------|
| `AudioDetail.get()`（`/api/audio/{id}` 接口） | `f"{self.site_url}/api/audio/..."`（实例属性逐请求更新，但端口已被反代剥掉） | 本次故障的直接来源 |
| `AudioUtils.get_audios()`（被书籍详情接口调用） | `f"{AudioUtils.site_url}/api/audio/..."` | 该缓存值实际恒为空串，历史上碰巧输出相对路径未暴露问题；一旦该逻辑被"修复"会立刻变成同样的丢端口故障 |
| 合集下载 `download_url` | `f"{self.get_site_url()}/api/audios/.../download?key=..."` | 同样丢端口，导致代理环境下复制/点击下载链接失效 |

### 修改方式

统一改为返回**相对路径**，由浏览器按当前页面 origin 自动解析，天然兼容任意端口、协议与子路径部署。共 6 处字符串前缀移除，均为机械替换：

```
f"{AudioUtils.site_url}/api/audio/{id}/{file}"   →  f"/api/audio/{id}/{file}"
f"{self.site_url}/api/audio/{id}/{file}"         →  f"/api/audio/{id}/{file}"   （2 处）
f"{self.site_url}/api/audio/{id}/{sub_file}"     →  f"/api/audio/{id}/{sub_file}" （2 处）
f"{self.get_site_url()}/api/audios/.../download" →  f"/api/audios/.../download"
```

说明：`AudioUtils.site_url` 及其赋值语句保持原样未删除，仅不再参与该 URL 拼接。

**保留绝对 URL 的场景（行为不变）**：Podcast 订阅源（消费方是站外客户端，走独立的 `_get_full_site_url()` 构造完整地址）、邮件推送站点链接等。

---

## 三、验证方式

1. 直连 `http://IP:PORT`：有声书播放、进度拖动正常（Range 请求返回 `206 Partial Content`）；放入同名 `.srt` 后字幕正常显示、点击可跳转、开关按钮生效；
2. 反向代理 + 非标准端口（如 `https://domain:50006`）：播放恢复正常（修复前必现阻断），`.wav` 请求开始出现在代理访问日志中；
3. m4b 内嵌章节共享外部字幕、普通音频独立字幕均验证；
4. 合集下载 zip 内包含字幕文件；页面内下载与复制链接均可正常使用；
5. 书籍详情页内嵌播放器入口同步验证；
6. Podcast 订阅源仍为绝对地址，客户端订阅不受影响；
7. 三语言界面下字幕开关提示文案正常显示。

## 四、兼容性与风险

- 前端各消费点均将 url 直接用于 `<audio>` / `new Audio()` / `a.href`，相对路径按当前 origin 解析，结果与"正确拼好的绝对地址"完全一致，无副作用；
- 若有第三方脚本依赖这两个内部接口返回绝对 URL 会受影响（属未在文档中承诺的内部接口，风险低）；
- 新增字段 `"subtitle"` 为可选字段，无字幕时不输出，旧前端不受影响；
- 不涉及鉴权、缓存、流式传输逻辑改动。

## 五、变更清单

```
webserver/constants.py               新增 SUPPORTED_SUBTITLE_FORMATS
webserver/handlers/audio.py          字幕扫描与接口字段；srt/vtt MIME；合集打包含字幕；
                                     音频/字幕/下载链接改相对路径（6 处）
app/src/pages/audio/_id.vue          SRT/VTT 解析、字幕显示与点击跳转、开关按钮
app/locales/{zh,zh-TW,en}.json       新增 audio.subtitle 文案
```


---

## 关联 Issue

Closes #27 （有声书能否支持SRT格式的字幕文件显示）
