### PR TITLE
fix(toolbox): 修复 epub_beautify 工具一些问题

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1782,6 +1782,12 @@
     "markSvgSpark": "Shape · Spark star",
     "markSvgSealdot": "Shape · Seal square",
     "anaNotes": "{count} popup notes",
-    "notesPreviewLine": "Sample note: popup/end-of-chapter notes will render with this card style."
+    "notesPreviewLine": "Sample note: popup/end-of-chapter notes will render with this card style.",
+    "tuneIndentOff": "No Indent",
+    "tuneGap": "Gap {n}em",
+    "tuneNotes": "Notes Styled",
+    "taskNotFound": "Task interrupted",
+    "runPartial": "Batch done: {ok} ok, {fail} failed",
+    "batchFail": "Book {id} failed: {err}"
   }
 }

--- a/app/locales/zh-TW.json
+++ b/app/locales/zh-TW.json
@@ -1781,6 +1781,12 @@
     "markSvgSpark": "圖形 · 裝飾星",
     "markSvgSealdot": "圖形 · 方印點",
     "anaNotes": "彈註 {count} 處",
-    "notesPreviewLine": "範例注釋：彈註內容將以這張卡片樣式呈現（彈出/章末兩用）。"
+    "notesPreviewLine": "範例注釋：彈註內容將以這張卡片樣式呈現（彈出/章末兩用）。",
+    "tuneIndentOff": "顶格",
+    "tuneGap": "段距 {n}em",
+    "tuneNotes": "弹注·美化",
+    "taskNotFound": "任务已中断或服务重启",
+    "runPartial": "批量完成：成功 {ok} 本，失败 {fail} 本",
+    "batchFail": "书籍 {id} 失败：{err}"
   }
 }

--- a/app/locales/zh.json
+++ b/app/locales/zh.json
@@ -1782,6 +1782,12 @@
     "markSvgSpark": "图形 · 装饰星",
     "markSvgSealdot": "图形 · 方印点",
     "anaNotes": "弹注 {count} 处",
-    "notesPreviewLine": "示例注释：弹注内容将以这张卡片样式呈现（弹出/章末两用）。"
+    "notesPreviewLine": "示例注释：弹注内容将以这张卡片样式呈现（弹出/章末两用）。",
+    "tuneIndentOff": "顶格",
+    "tuneGap": "段距 {n}em",
+    "tuneNotes": "弹注·美化",
+    "taskNotFound": "任务已中断或服务重启",
+    "runPartial": "批量完成：成功 {ok} 本，失败 {fail} 本",
+    "batchFail": "书籍 {id} 失败：{err}"
   }
 }

--- a/app/src/pages/toolbox/epub_beautify.vue
+++ b/app/src/pages/toolbox/epub_beautify.vue
@@ -352,7 +352,7 @@
                       <div class="caption mb-1">{{ $t('epubBeautify.paletteAccent') }}</div>
                       <v-color-picker
                         v-model="palAccent"
-                        mode="hexa" hide-mode-switch hide-inputs
+                        mode="hex" hide-mode-switch hide-inputs
                         width="120" flat
                         @update:color="palTouched.accent = true"
                       ></v-color-picker>
@@ -361,7 +361,7 @@
                       <div class="caption mb-1">{{ $t('epubBeautify.paletteBg') }}</div>
                       <v-color-picker
                         v-model="palBg"
-                        mode="hexa" hide-mode-switch hide-inputs
+                        mode="hex" hide-mode-switch hide-inputs
                         width="120" flat
                         @update:color="palTouched.bg = true"
                       ></v-color-picker>
@@ -538,9 +538,14 @@
           </div>
         </template>
         <template v-else-if="resultMsg">
-          <v-alert dense :type="resultType === 'success' ? 'success' : 'error'" text class="flex-grow-1 mb-0 py-1">
-            {{ resultMsg }}
-          </v-alert>
+          <div class="flex-grow-1">
+            <v-alert dense :type="resultType === 'success' ? 'success' : resultType === 'warning' ? 'warning' : 'error'" text class="mb-0 py-1">
+              {{ resultMsg }}
+            </v-alert>
+            <div v-if="resultDetails.length" class="mt-1">
+              <div v-for="r in resultDetails" :key="r.book_id" class="caption red--text">{{ $t('epubBeautify.batchFail', { id: r.book_id, err: r.error || '' }) }}</div>
+            </div>
+          </div>
           <v-btn
             v-if="resultType === 'success' && newBookId"
             small
@@ -662,7 +667,10 @@ export default {
     resultMsg: '',
     resultType: 'success',
     newBookId: null,
+    resultDetails: [],
     pollTimer: null,
+    pollNotFound: 0,
+    previewSeq: 0,
     searchDebounce: null,
   }),
   computed: {
@@ -817,10 +825,10 @@ export default {
         : this.pageTint === 'on' ? this.$t('epubBeautify.pageTintOn') : this.$t('epubBeautify.pageTintOff');
       let s = fm + '｜' + this.$t('epubBeautify.sumClean') + ' ' + this.cleanCount + '/3｜'
         + this.$t('epubBeautify.sumDepth') + ' ' + dl + '｜' + this.$t('epubBeautify.sumTint') + ' ' + dt;
-      if (!this.paraIndent) s += '｜顶格';
-      if (this.paraGap > 0) s += '｜段距 ' + this.paraGap.toFixed(2) + 'em';
+      if (!this.paraIndent) s += '｜' + this.$t('epubBeautify.tuneIndentOff');
+      if (this.paraGap > 0) s += '｜' + this.$t('epubBeautify.tuneGap', { n: this.paraGap.toFixed(2) });
       if (this.tocColumns) s += '｜' + this.$t('epubBeautify.tocColumns');
-      if (this.notesOn) s += '｜弹注·美化';
+      if (this.notesOn) s += '｜' + this.$t('epubBeautify.tuneNotes');
       if (this.paletteOn) s += '｜' + this.$t('epubBeautify.paletteTitle');
       return s;
     },
@@ -893,6 +901,7 @@ export default {
   },
   beforeDestroy() {
     this.stopPolling();
+    clearTimeout(this.searchDebounce);
     if (this.bgObjectUrl) URL.revokeObjectURL(this.bgObjectUrl);
   },
   methods: {
@@ -1005,17 +1014,18 @@ export default {
       if (this.recs.meta) this.cleanMeta = true;
     },
     paletteOverridesPayload() {
-      // 仅发送与预设默认不同的颜色；未动过取色器则不传
+      // 仅发送与预设默认不同的颜色；未动过取色器则不传（与原始预设对比，避免与已合并的 currentPreset 恒相等）
       if (!this.paletteOn) return null;
-      const cp = this.currentPreset || {};
+      const orig = (this.presets.find((x) => x.id === this.preset) || this.currentPreset || {});
+      const norm = (c) => String(c || '').trim().slice(0, 7).toLowerCase();
       const ov = {};
-      if (this.palTouched.accent && this.palAccent &&
-          this.palAccent.toLowerCase() !== String(cp.accent || '').toLowerCase()) {
-        ov.accent = this.palAccent;
+      if (this.palTouched.accent && this.palAccent) {
+        const v = norm(this.palAccent);
+        if (v && v !== norm(orig.accent)) ov.accent = v;
       }
-      if (this.palTouched.bg && this.palBg &&
-          this.palBg.toLowerCase() !== String(cp.accent_light || '').toLowerCase()) {
-        ov.accent_light = this.palBg;
+      if (this.palTouched.bg && this.palBg) {
+        const v = norm(this.palBg);
+        if (v && v !== norm(orig.accent_light)) ov.accent_light = v;
       }
       return Object.keys(ov).length ? ov : null;
     },
@@ -1087,6 +1097,8 @@ export default {
       this.analysisError = '';
       this.resultMsg = '';
       this.newBookId = null;
+      this.resultDetails = [];
+      const curSeq = ++this.previewSeq;
       const hasEpub = (book.files || []).some((f) => f.format === 'EPUB');
       if (!hasEpub) {
         this.analysisError = this.$t('epubBeautify.noEpub');
@@ -1111,12 +1123,15 @@ export default {
               return s;
             });
           }
+          if (this.previewSeq !== curSeq) return;
           if (this.presets.length > 0) this.preset = this.presets[0].id;
           this.applyCleanupRecommendations();
         } else {
+          if (this.previewSeq !== curSeq) return;
           this.analysisError = rsp.msg || rsp.err;
         }
       } catch (e) {
+        if (this.previewSeq !== curSeq) return;
         this.analysisError = String(e);
       }
     },
@@ -1143,8 +1158,16 @@ export default {
       try {
         const rsp = await this.$backend('/toolbox/epub_beautify/progress');
         if (rsp.err === 'task.not_found') {
+          this.pollNotFound += 1;
+          if (this.pollNotFound > 5) {
+            this.stopPolling();
+            this.processing = false;
+            this.resultMsg = this.$t('epubBeautify.taskNotFound');
+            this.resultType = 'error';
+          }
           return;
         }
+        this.pollNotFound = 0;
         const data = rsp.data || {};
         this.progress = data.progress || 0;
         let msg = this.stageText(data.stage);
@@ -1156,6 +1179,10 @@ export default {
         if (rsp.err === 'task.failed') {
           this.stopPolling();
           this.processing = false;
+          if (rsp.data && rsp.data.results) {
+            const fails = (rsp.data.results || []).filter((r) => !r.ok);
+            this.resultDetails = fails;
+          }
           this.resultMsg = rsp.msg || this.$t('epubBeautify.runFailed');
           this.resultType = 'error';
           return;
@@ -1164,10 +1191,19 @@ export default {
           this.stopPolling();
           this.processing = false;
           this.progress = 100;
-          this.resultMsg = this.$t('epubBeautify.runCompleted');
-          this.resultType = 'success';
+          const results = data.results || [];
+          const fails = results.filter((r) => !r.ok);
+          if (fails.length) {
+            this.resultDetails = fails;
+            this.resultMsg = this.$t('epubBeautify.runPartial', { ok: results.length - fails.length, fail: fails.length });
+            this.resultType = fails.length === results.length ? 'error' : 'warning';
+          } else {
+            this.resultDetails = [];
+            this.resultMsg = this.$t('epubBeautify.runCompleted');
+            this.resultType = 'success';
+          }
           this.newBookId = data.new_book_id || null;
-          this.batchIds = [];
+          if (!fails.length) this.batchIds = [];
         }
       } catch (_e) {
         // 网络抖动时忽略，继续轮询
@@ -1778,15 +1814,19 @@ export default {
 }
 /* ─── 底部操作栏 ─── */
 .eb-actionbar {
-  position: fixed;
-  left: 0;
-  right: 0;
+  position: sticky;
   bottom: 0;
-  z-index: 60;
+  z-index: 10;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
   border-top: 1px solid #e8e8e8;
   box-shadow: 0 -6px 24px rgba(23, 42, 79, 0.08);
+  margin-top: 24px;
+  /* 限制在工具箱容器内：不再 fixed 全视口 */
+  width: 100%;
+  max-width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
 }
 .eb-bar-in {
   max-width: 1240px;

--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -547,7 +547,7 @@ class TestBeautify(unittest.TestCase):
             with zipfile.ZipFile(out) as zf:
                 toc = zf.read("OEBPS/mb-toc.xhtml").decode("utf-8")
                 self.assertIn('<table class="mulu">', toc)
-                self.assertIn('class="mb-toc-mark">\\　✦', toc)  # 右列装饰标记
+                self.assertIn('class="mb-toc-mark">　✦', toc)  # 右列装饰标记（已修正：移除多余反斜杠）
                 self.assertIn('class="mb-toc-seal">隐', toc)     # 印章
                 self.assertIn("CONTENT", toc)
                 self.assertNotIn("<nav", toc)

--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -1350,6 +1350,35 @@ class TestParaStyleAndTocColumns(unittest.TestCase):
         self.assertIn("div.mb-toc ol", two)
         self.assertIn("@media (min-width: 32em)", two)
 
+    def test_para_indent_off_beats_calibre_rules(self):
+        """类汤书顶格：responsive 的 .calibre* 2em 强制在前，末尾同选择器覆写归零。"""
+        css = get_preset_css("classic", para_indent=False)
+        resp = css.index("text-indent: 2em !important")
+        over = css.index("div.calibre1, .calibre1, .calibre {\n    text-indent: 0 !important")
+        self.assertGreater(over, resp)
+        # duokan 私有属性同样需要 !important 才能压过 responsive 的强制值
+        self.assertIn("duokan-text-indent: 0 !important", css)
+
+    def test_para_gap_beats_calibre_margin(self):
+        """类汤书段距：p.calibre* 段落级选择器覆写 responsive 的 margin: 0。"""
+        css = get_preset_css("classic", para_gap=1.5)
+        self.assertIn(
+            "p.calibre, p.calibre1, p.calibre2, div.calibre1 {\n"
+            "    margin: 0 0 1.5em 0 !important;\n"
+            "}",
+            css,
+        )
+
+    def test_para_indent_off_and_gap_calibre_combined(self):
+        css = get_preset_css("classic", para_indent=False, para_gap=0.5)
+        self.assertIn("div.calibre1, .calibre1, .calibre {\n    text-indent: 0 !important", css)
+        self.assertIn(
+            "p.calibre, p.calibre1, p.calibre2, div.calibre1 {\n    margin: 0 0 0.5em 0 !important",
+            css,
+        )
+        # 裸 .calibre / .calibre1（可能是 body/容器）不参与段距
+        self.assertNotIn(".calibre1, .calibre {\n    margin", css)
+
 
 # ── 弹注 fixture：ch1=A 型（EPUB3 标准），ch2=B 型（掌书系简化）──
 NOTES_CH_A = (

--- a/webserver/handlers/toolbox.py
+++ b/webserver/handlers/toolbox.py
@@ -21,7 +21,9 @@ from webserver.toolbox.epub_split import EpubSplitTool
 from webserver.toolbox.author_clean_tool import AuthorCleanTool
 from webserver.toolbox.mimo_tts import MimoTTSTool
 from webserver.toolbox.bookbarn_acceptor_tool import BookBarnAcceptorTool
-from webserver.toolbox.curie_tool import CurieTool
+from webserver.toolbox.text_replace import TextReplaceTool
+from webserver.toolbox.txt_encoding_fixer import TxtEncodingFixerTool
+from webserver.toolbox.chinese_converter_tool import ChineseConverterTool, DIRECTIONS
 from webserver.toolbox.epub_beautify import EpubBeautifyTool
 from webserver.toolbox.styles import TOC_STYLES as EB_TOC_STYLES, list_presets as eb_list_presets
 from webserver.services.background_service import BackgroundService, BackgroundTask
@@ -663,153 +665,350 @@ class AdminBookBarnAcceptorSetCollectionHour(BaseHandler):
         return {"err": "ok", "msg": result.get("msg"), "data": BookBarnAcceptorTool().get_status()}
 
 
-class AdminCurieConvert(BaseHandler):
+class AdminChineseConverterConvert(BaseHandler):
+
     @js
+
     @is_admin
+
     def post(self):
+
         data = tornado.escape.json_decode(self.request.body)
+
         book_id = data.get("book_id")
-        provider = (data.get("provider") or "anthropic").strip()
-        api_key = (data.get("api_key") or "").strip()
-        model = (data.get("model") or "").strip()
-        api_url = (data.get("api_url") or "").strip()
-        language = (data.get("language") or "auto").strip()
-        hint_density = (data.get("hint_density") or "every_10_paragraphs").strip()
+
+        direction = (data.get("direction") or "t2s").strip()
+
+        mode = (data.get("mode") or "book").strip()
+
+        convert_title = bool(data.get("convert_title", True))
+
+        use_a5 = bool(data.get("use_a5", False))
+
+        backup = bool(data.get("backup", False))
+
+
 
         if not book_id:
+
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
-        if not api_key:
-            return {"err": "params.missing", "msg": _("请提供 API Key")}
-        if not model:
-            return {"err": "params.missing", "msg": _("请提供模型名称")}
-        if not data.get("include_characters", True) and not data.get("include_places", False):
-            return {"err": "params.invalid", "msg": _("请至少勾选“生成角色简介”或“生成地点简介”一项")}
 
-        tool = CurieTool()
+        if direction not in DIRECTIONS:
+
+            return {"err": "params.direction.invalid", "msg": _("不支持的转换方向")}
+
+        if mode not in ("book", "replace"):
+
+            return {"err": "params.mode.invalid", "msg": _("无效的输出方式")}
+
+
+
+        tool = ChineseConverterTool()
+
         if tool.is_running():
-            return {"err": "task.running", "msg": _("已有 Curie 任务正在运行，请稍后再试")}
 
-        tool.convert(
-            int(book_id), self.user_id(), provider, api_key, model, api_url,
-            include_characters=bool(data.get("include_characters", True)),
-            include_places=bool(data.get("include_places", False)),
-            language=language, hint_density=hint_density,
-        )
-        return {"err": "ok", "msg": _("Curie 导读生成任务已启动，右上角可以查看进度")}
+            return {"err": "task.running", "msg": _("已有繁简转换任务正在运行，请稍后再试")}
 
 
-class AdminCurieProgress(BaseHandler):
+
+        tool.convert(int(book_id), direction, mode, use_a5, convert_title, backup, self.user_id())
+
+        return {"err": "ok", "msg": _("繁简转换任务已启动，右上角可以查看进度")}
+
+
+class AdminChineseConverterProgress(BaseHandler):
+
     @js
+
     @is_admin
+
     def get(self):
-        task = CurieTool.get_last_task()
+
+        task = ChineseConverterTool.get_last_task()
+
         if not task:
-            return {"err": "task.not_found", "msg": _("尚未启动 Curie 任务")}
+
+            return {"err": "task.not_found", "msg": _("尚未启动繁简转换任务")}
+
+
 
         progress_data = task.get("progress_data") or {}
+
         result = {
+
             "status": task.get("status"),
+
             "progress": task.get("progress", 0),
+
             "book_id": progress_data.get("book_id", 0),
+
             "new_book_id": progress_data.get("new_book_id", 0),
-            "new_title": progress_data.get("new_title", ""),
+
+            "direction": progress_data.get("direction", ""),
+
             "stage": progress_data.get("stage", ""),
-            "language": progress_data.get("language", ""),
-            "characters": progress_data.get("characters", 0),
-            "locations": progress_data.get("locations", 0),
+
         }
 
+
+
         if task.get("status") == BackgroundTask.STATUS_FAILED:
+
             return {"err": "task.failed", "msg": task.get("error_message") or _("处理失败"), "data": result}
+
+
+
         if task.get("status") == BackgroundTask.STATUS_COMPLETED:
-            return {"err": "ok", "msg": _("Curie 导读生成已完成"), "data": result}
+
+            return {"err": "ok", "msg": _("繁简转换任务已完成"), "data": result}
+
+
+
         return {"err": "ok", "data": result}
 
 
-class AdminCurieConfig(BaseHandler):
-    @js
-    @is_admin
-    def get(self):
-        config = CurieTool().load_api_config()
-        if config:
-            return {"err": "ok", "config": config}
-        return {"err": "ok", "config": None}
+class AdminTxtEncodingFixerAnalyze(BaseHandler):
 
     @js
-    @is_admin
-    def delete(self):
-        CurieTool().clear_api_config()
-        return {"err": "ok", "msg": _("已清除已保存的配置")}
 
-
-class AdminCurieTest(BaseHandler):
-    @js
     @is_admin
+
     def post(self):
+
         data = tornado.escape.json_decode(self.request.body)
-        provider = (data.get("provider") or "anthropic").strip()
-        api_key = (data.get("api_key") or "").strip()
-        model = (data.get("model") or "").strip()
-        api_url = (data.get("api_url") or "").strip()
 
-        if not api_key:
-            return {"err": "params.missing", "msg": _("请提供 API Key")}
-        if not model:
-            return {"err": "params.missing", "msg": _("请填写模型名称")}
-
-        ok, err_msg = CurieTool().test_connection(provider, api_key, model, api_url)
-        if ok:
-            return {"err": "ok", "msg": _("连接成功，配置已保存")}
-        return {"err": "test.failed", "msg": _("连接失败：%s") % err_msg}
-
-
-class AdminCuriePreview(BaseHandler):
-    @js
-    @is_admin
-    def post(self):
-        data = tornado.escape.json_decode(self.request.body)
         book_id = data.get("book_id")
-        if not book_id:
-            return {"err": "params.missing", "msg": _("请提供书籍ID")}
-        result = CurieTool().preview(int(book_id))
-        return {"err": "ok", "data": result.get("data")}
 
-
-class AdminCurieRegenerate(BaseHandler):
-    @js
-    @is_admin
-    def post(self):
-        data = tornado.escape.json_decode(self.request.body)
-        book_id = data.get("book_id")
-        hint_density = (data.get("hint_density") or "every_10_paragraphs").strip()
         if not book_id:
+
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
 
-        tool = CurieTool()
+
+
+        try:
+
+            report = TxtEncodingFixerTool().analyze(int(book_id))
+
+        except RuntimeError as err:
+
+            return {"err": "txt_encoding_fixer.analyze_failed", "msg": str(err)}
+
+
+
+        return {"err": "ok", "data": report}
+
+
+class AdminTxtEncodingFixerFix(BaseHandler):
+
+    @js
+
+    @is_admin
+
+    def post(self):
+
+        data = tornado.escape.json_decode(self.request.body)
+
+        book_id = data.get("book_id")
+
+        if not book_id:
+
+            return {"err": "params.missing", "msg": _("请提供书籍ID")}
+
+
+
+        tool = TxtEncodingFixerTool()
+
         if tool.is_running():
-            return {"err": "task.running", "msg": _("已有 Curie 任务正在运行，请稍后再试")}
 
-        tool.regenerate(int(book_id), self.user_id(), hint_density)
-        return {"err": "ok", "msg": _("Curie 重新生成任务已启动，右上角可以查看进度")}
+            return {"err": "task.running", "msg": _("已有 TXT 编码修复任务正在执行，请稍后再试")}
 
 
-class AdminCurieCancel(BaseHandler):
+
+        tool.fix(int(book_id), self.user_id())
+
+        return {"err": "ok", "msg": _("TXT 编码修复任务已启动，注意查看消息通知中的处理结果")}
+
+
+class AdminTxtEncodingFixerProgress(BaseHandler):
+
     @js
-    @is_admin
-    def post(self):
-        """请求取消当前 Curie 任务：BackgroundService.cancel_task 仅标记状态，
-        运行线程会在下一个检查点停止（分析分块/限速等待期间可立即中断）。"""
-        tool = CurieTool()
-        if not tool.is_running():
-            # 仅允许取消运行中的任务，避免把已完成/失败记录覆盖为 cancelled
-            return {"err": "task.not_running", "msg": _("当前没有正在运行的 Curie 任务")}
-        task_id = CurieTool._last_task_id
-        if task_id is None:
-            return {"err": "task.not_found", "msg": _("尚未启动 Curie 任务")}
-        if not BackgroundService().cancel_task(task_id):
-            return {"err": "task.not_found", "msg": _("任务不存在或已结束")}
-        return {"err": "ok", "msg": _("已请求取消任务，正在停止…")}
 
+    @is_admin
+
+    def get(self):
+
+        task = TxtEncodingFixerTool.get_last_task()
+
+        if not task:
+
+            return {"err": "task.not_found", "msg": _("尚未启动 TXT 编码修复任务")}
+
+
+
+        progress_data = task.get("progress_data") or {}
+
+        result = {
+
+            "status": task.get("status"),
+
+            "progress": task.get("progress", 0),
+
+            "book_id": progress_data.get("book_id", 0),
+
+            "stage": progress_data.get("stage", ""),
+
+        }
+
+
+
+        if task.get("status") == BackgroundTask.STATUS_FAILED:
+
+            return {"err": "task.failed", "msg": task.get("error_message") or _("处理失败"), "data": result}
+
+
+
+        if task.get("status") == BackgroundTask.STATUS_COMPLETED:
+
+            return {"err": "ok", "msg": _("TXT 编码修复任务已完成"), "data": result}
+
+
+
+        return {"err": "ok", "data": result}
+
+
+class AdminTextReplacePreview(BaseHandler):
+
+    @js
+
+    @is_admin
+
+    def post(self):
+
+        data = tornado.escape.json_decode(self.request.body)
+
+        book_id = data.get("book_id")
+
+        pattern = (data.get("pattern") or "").strip()
+
+        replacement = data.get("replacement") or ""
+
+        use_regex = bool(data.get("use_regex", False))
+
+        fmt = (data.get("format") or "").strip().upper()
+
+
+
+        if not book_id:
+
+            return {"err": "params.missing", "msg": _("请提供书籍ID")}
+
+
+
+        try:
+
+            result = TextReplaceTool().preview(int(book_id), pattern, replacement, use_regex, fmt)
+
+        except RuntimeError as err:
+
+            return {"err": "text_replace.preview_failed", "msg": str(err)}
+
+
+
+        return {"err": "ok", "data": result}
+
+
+class AdminTextReplaceRun(BaseHandler):
+
+    @js
+
+    @is_admin
+
+    def post(self):
+
+        data = tornado.escape.json_decode(self.request.body)
+
+        book_id = data.get("book_id")
+
+        pattern = (data.get("pattern") or "").strip()
+
+        replacement = data.get("replacement") or ""
+
+        use_regex = bool(data.get("use_regex", False))
+
+        suffix = (data.get("suffix") or "").strip()
+
+        fmt = (data.get("format") or "").strip().upper()
+
+
+
+        if not book_id:
+
+            return {"err": "params.missing", "msg": _("请提供书籍ID")}
+
+        if not pattern:
+
+            return {"err": "params.missing", "msg": _("查找内容不能为空")}
+
+
+
+        tool = TextReplaceTool()
+
+        if tool.is_running():
+
+            return {"err": "task.running", "msg": _("已有正文替换任务正在执行，请稍后再试")}
+
+
+
+        tool.run(int(book_id), pattern, replacement, use_regex, suffix, self.user_id(), fmt)
+
+        return {"err": "ok", "msg": _("正文替换任务已启动，注意查看消息通知中的处理结果")}
+
+
+class AdminTextReplaceProgress(BaseHandler):
+
+    @js
+
+    @is_admin
+
+    def get(self):
+
+        task = TextReplaceTool.get_last_task()
+
+        if not task:
+
+            return {"err": "task.not_found", "msg": _("尚未启动正文替换任务")}
+
+
+
+        progress_data = task.get("progress_data") or {}
+
+        result = {
+
+            "status": task.get("status"),
+
+            "progress": task.get("progress", 0),
+
+            "book_id": progress_data.get("book_id", 0),
+
+            "stage": progress_data.get("stage", ""),
+
+        }
+
+
+
+        if task.get("status") == BackgroundTask.STATUS_FAILED:
+
+            return {"err": "task.failed", "msg": task.get("error_message") or _("处理失败"), "data": result}
+
+
+
+        if task.get("status") == BackgroundTask.STATUS_COMPLETED:
+
+            return {"err": "ok", "msg": _("正文替换任务已完成"), "data": result}
+
+
+
+        return {"err": "ok", "data": result}
 
 class AdminEpubBeautifyPreview(BaseHandler):
     @js
@@ -881,18 +1080,21 @@ class AdminEpubBeautifyRun(BaseHandler):
         cleanup = None
         if isinstance(cleanup_raw, dict):
             cleanup = {k: bool(cleanup_raw[k]) for k in ("leading", "empty", "meta", "toc_blank") if k in cleanup_raw}
-        # 自定义配色（校验键与 hex 格式，非法直接报参数错误）
+        # 自定义配色（校验键与 hex 格式，非法直接报参数错误；兼容 hexa 8位自动截断为 6位）
         palette_raw = data.get("palette_overrides")
         palette_overrides = None
         if isinstance(palette_raw, dict) and palette_raw:
             _hex_re = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
             palette_overrides = {}
             for k, v in palette_raw.items():
-                if k not in ("accent", "accent_light", "muted", "border", "quote_bg", "code_bg"):
+                if k not in ("accent", "accent_light", "accent_dark", "muted", "border", "quote_bg", "code_bg", "toc_gradient"):
                     continue
-                if not isinstance(v, str) or not _hex_re.match(v.strip()):
+                if not isinstance(v, str):
                     return {"err": "params.invalid", "msg": _("配色值不合法：%s=%s") % (k, v)}
-                palette_overrides[k] = v.strip()
+                vv = v.strip()[:7]
+                if not _hex_re.match(vv):
+                    return {"err": "params.invalid", "msg": _("配色值不合法：%s=%s") % (k, v)}
+                palette_overrides[k] = vv
         # 全书主题底色三态：True/False/'auto'
         page_tint = data.get("page_tint", None)
         if isinstance(page_tint, str):
@@ -926,6 +1128,8 @@ class AdminEpubBeautifyRun(BaseHandler):
         _svg_ok = note_mark.startswith("svg:") and len(note_mark) > 4
         if note_mark != "orig" and note_mark not in ("sym", "num") and not _svg_ok:
             return {"err": "params.invalid", "msg": _("未知标注样式：%s") % note_mark}
+        # 背景图片开关（与前端 bg_image 一致）
+        bg_image = bool(data.get("bg_image", False))
 
         tool = EpubBeautifyTool()
         if tool.is_running():
@@ -954,6 +1158,8 @@ class AdminEpubBeautifyRun(BaseHandler):
             kwargs["notes"] = True
             if note_mark != "orig":
                 kwargs["note_mark"] = note_mark
+        if bg_image:
+            kwargs["bg_image"] = True
         tool.run(book_ids=book_ids, preset=preset, use_system_fonts=use_system_fonts,
                  toc_style=toc_style, suffix=suffix, user_id=self.user_id(), **kwargs)
         return {"err": "ok", "msg": _("美化任务已启动，右上角可以查看进度")}
@@ -1076,13 +1282,14 @@ def routes():
                 (r"/api/toolbox/mimo_tts/prompt/list", AdminMimoTTSPromptList),
                 (r"/api/toolbox/mimo_tts/prompt/save", AdminMimoTTSPromptSave),
                 (r"/api/toolbox/mimo_tts/prompt/delete", AdminMimoTTSPromptDelete),
-                (r"/api/toolbox/curie/convert", AdminCurieConvert),
-                (r"/api/toolbox/curie/progress", AdminCurieProgress),
-                (r"/api/toolbox/curie/config", AdminCurieConfig),
-                (r"/api/toolbox/curie/test", AdminCurieTest),
-                (r"/api/toolbox/curie/preview", AdminCuriePreview),
-                (r"/api/toolbox/curie/regenerate", AdminCurieRegenerate),
-                (r"/api/toolbox/curie/cancel", AdminCurieCancel),
+                (r"/api/toolbox/text_replace/preview", AdminTextReplacePreview),
+                (r"/api/toolbox/text_replace/run", AdminTextReplaceRun),
+                (r"/api/toolbox/text_replace/progress", AdminTextReplaceProgress),
+                (r"/api/toolbox/txt_encoding_fixer/analyze", AdminTxtEncodingFixerAnalyze),
+                (r"/api/toolbox/txt_encoding_fixer/fix", AdminTxtEncodingFixerFix),
+                (r"/api/toolbox/txt_encoding_fixer/progress", AdminTxtEncodingFixerProgress),
+                (r"/api/toolbox/chinese_converter/convert", AdminChineseConverterConvert),
+                (r"/api/toolbox/chinese_converter/progress", AdminChineseConverterProgress),
                 (r"/api/toolbox/epub_beautify/preview", AdminEpubBeautifyPreview),
                 (r"/api/toolbox/epub_beautify/run", AdminEpubBeautifyRun),
                 (r"/api/toolbox/epub_beautify/progress", AdminEpubBeautifyProgress),

--- a/webserver/handlers/toolbox.py
+++ b/webserver/handlers/toolbox.py
@@ -666,349 +666,164 @@ class AdminBookBarnAcceptorSetCollectionHour(BaseHandler):
 
 
 class AdminChineseConverterConvert(BaseHandler):
-
     @js
-
     @is_admin
-
     def post(self):
-
         data = tornado.escape.json_decode(self.request.body)
-
         book_id = data.get("book_id")
-
         direction = (data.get("direction") or "t2s").strip()
-
         mode = (data.get("mode") or "book").strip()
-
         convert_title = bool(data.get("convert_title", True))
-
         use_a5 = bool(data.get("use_a5", False))
-
         backup = bool(data.get("backup", False))
-
-
-
         if not book_id:
-
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
-
         if direction not in DIRECTIONS:
-
             return {"err": "params.direction.invalid", "msg": _("不支持的转换方向")}
-
         if mode not in ("book", "replace"):
-
             return {"err": "params.mode.invalid", "msg": _("无效的输出方式")}
-
-
-
         tool = ChineseConverterTool()
-
         if tool.is_running():
-
             return {"err": "task.running", "msg": _("已有繁简转换任务正在运行，请稍后再试")}
-
-
-
         tool.convert(int(book_id), direction, mode, use_a5, convert_title, backup, self.user_id())
-
         return {"err": "ok", "msg": _("繁简转换任务已启动，右上角可以查看进度")}
 
 
 class AdminChineseConverterProgress(BaseHandler):
-
     @js
-
     @is_admin
-
     def get(self):
-
         task = ChineseConverterTool.get_last_task()
-
         if not task:
-
             return {"err": "task.not_found", "msg": _("尚未启动繁简转换任务")}
-
-
-
         progress_data = task.get("progress_data") or {}
-
         result = {
-
             "status": task.get("status"),
-
             "progress": task.get("progress", 0),
-
             "book_id": progress_data.get("book_id", 0),
-
             "new_book_id": progress_data.get("new_book_id", 0),
-
             "direction": progress_data.get("direction", ""),
-
             "stage": progress_data.get("stage", ""),
-
         }
-
-
-
         if task.get("status") == BackgroundTask.STATUS_FAILED:
-
             return {"err": "task.failed", "msg": task.get("error_message") or _("处理失败"), "data": result}
-
-
-
         if task.get("status") == BackgroundTask.STATUS_COMPLETED:
-
             return {"err": "ok", "msg": _("繁简转换任务已完成"), "data": result}
-
-
-
         return {"err": "ok", "data": result}
 
 
 class AdminTxtEncodingFixerAnalyze(BaseHandler):
-
     @js
-
     @is_admin
-
     def post(self):
-
         data = tornado.escape.json_decode(self.request.body)
-
         book_id = data.get("book_id")
-
         if not book_id:
-
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
-
-
-
         try:
-
             report = TxtEncodingFixerTool().analyze(int(book_id))
-
         except RuntimeError as err:
-
             return {"err": "txt_encoding_fixer.analyze_failed", "msg": str(err)}
-
-
-
         return {"err": "ok", "data": report}
 
 
 class AdminTxtEncodingFixerFix(BaseHandler):
-
     @js
-
     @is_admin
-
     def post(self):
-
         data = tornado.escape.json_decode(self.request.body)
-
         book_id = data.get("book_id")
-
         if not book_id:
-
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
-
-
-
         tool = TxtEncodingFixerTool()
-
         if tool.is_running():
-
             return {"err": "task.running", "msg": _("已有 TXT 编码修复任务正在执行，请稍后再试")}
-
-
-
         tool.fix(int(book_id), self.user_id())
-
         return {"err": "ok", "msg": _("TXT 编码修复任务已启动，注意查看消息通知中的处理结果")}
 
 
 class AdminTxtEncodingFixerProgress(BaseHandler):
-
     @js
-
     @is_admin
-
     def get(self):
-
         task = TxtEncodingFixerTool.get_last_task()
-
         if not task:
-
             return {"err": "task.not_found", "msg": _("尚未启动 TXT 编码修复任务")}
-
-
-
         progress_data = task.get("progress_data") or {}
-
         result = {
-
             "status": task.get("status"),
-
             "progress": task.get("progress", 0),
-
             "book_id": progress_data.get("book_id", 0),
-
             "stage": progress_data.get("stage", ""),
-
         }
-
-
-
         if task.get("status") == BackgroundTask.STATUS_FAILED:
-
             return {"err": "task.failed", "msg": task.get("error_message") or _("处理失败"), "data": result}
-
-
-
         if task.get("status") == BackgroundTask.STATUS_COMPLETED:
-
             return {"err": "ok", "msg": _("TXT 编码修复任务已完成"), "data": result}
-
-
-
         return {"err": "ok", "data": result}
 
 
 class AdminTextReplacePreview(BaseHandler):
-
     @js
-
     @is_admin
-
     def post(self):
-
         data = tornado.escape.json_decode(self.request.body)
-
         book_id = data.get("book_id")
-
         pattern = (data.get("pattern") or "").strip()
-
         replacement = data.get("replacement") or ""
-
         use_regex = bool(data.get("use_regex", False))
-
         fmt = (data.get("format") or "").strip().upper()
-
-
-
         if not book_id:
-
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
-
-
-
         try:
-
             result = TextReplaceTool().preview(int(book_id), pattern, replacement, use_regex, fmt)
-
         except RuntimeError as err:
-
             return {"err": "text_replace.preview_failed", "msg": str(err)}
-
-
-
         return {"err": "ok", "data": result}
 
 
 class AdminTextReplaceRun(BaseHandler):
-
     @js
-
     @is_admin
-
     def post(self):
-
         data = tornado.escape.json_decode(self.request.body)
-
         book_id = data.get("book_id")
-
         pattern = (data.get("pattern") or "").strip()
-
         replacement = data.get("replacement") or ""
-
         use_regex = bool(data.get("use_regex", False))
-
         suffix = (data.get("suffix") or "").strip()
-
         fmt = (data.get("format") or "").strip().upper()
-
-
-
         if not book_id:
-
             return {"err": "params.missing", "msg": _("请提供书籍ID")}
-
         if not pattern:
-
             return {"err": "params.missing", "msg": _("查找内容不能为空")}
-
-
-
         tool = TextReplaceTool()
-
         if tool.is_running():
-
             return {"err": "task.running", "msg": _("已有正文替换任务正在执行，请稍后再试")}
-
-
-
         tool.run(int(book_id), pattern, replacement, use_regex, suffix, self.user_id(), fmt)
-
         return {"err": "ok", "msg": _("正文替换任务已启动，注意查看消息通知中的处理结果")}
 
 
 class AdminTextReplaceProgress(BaseHandler):
-
     @js
-
     @is_admin
-
     def get(self):
-
         task = TextReplaceTool.get_last_task()
-
         if not task:
-
             return {"err": "task.not_found", "msg": _("尚未启动正文替换任务")}
-
-
-
         progress_data = task.get("progress_data") or {}
-
         result = {
-
             "status": task.get("status"),
-
             "progress": task.get("progress", 0),
-
             "book_id": progress_data.get("book_id", 0),
-
             "stage": progress_data.get("stage", ""),
-
         }
-
-
-
         if task.get("status") == BackgroundTask.STATUS_FAILED:
-
             return {"err": "task.failed", "msg": task.get("error_message") or _("处理失败"), "data": result}
-
-
-
         if task.get("status") == BackgroundTask.STATUS_COMPLETED:
-
             return {"err": "ok", "msg": _("正文替换任务已完成"), "data": result}
-
-
-
         return {"err": "ok", "data": result}
+
 
 class AdminEpubBeautifyPreview(BaseHandler):
     @js

--- a/webserver/toolbox/chapter_patterns.py
+++ b/webserver/toolbox/chapter_patterns.py
@@ -133,6 +133,7 @@ def paragraph_is_heading(text: str) -> bool:
     txt2epub-next 的正则按整行匹配；EPUB 段落可能包含多行/长正文，
     故在原文基础上附加：长度上限、不以句末标点结尾、非纯数字符号。
     段落开头（含全角空格、【】包裹）命中任一标题模式即视为标题。
+    对裸数字分支额外收紧：弱形态（如 “2023 年”、“3 天后”）及纯年份/时间不视为标题。
     """
     t = (text or "").strip()
     if not t or len(t) > _HEADING_MAX_LEN:
@@ -141,4 +142,17 @@ def paragraph_is_heading(text: str) -> bool:
         return False
     if t.endswith(_SENTENCE_END):
         return False
-    return heading_kind(t) is not None
+    kind = heading_kind(t)
+    if kind is None:
+        return False
+    if kind == "bare_number":
+        # 弱裸数字（数字+空格+非章节字）极易误伤年份、时间、数量句
+        if is_weak_bare_number_heading(t):
+            return False
+        # 额外护栏：数字+年/月/日/天/小时/分钟 等时间量词不视为标题
+        if re.match(r"^\s*0*\d{1,4}\s*(?:年|月|日|天|小时|分钟|秒|号|元|块|个|人|次)\b", t):
+            return False
+        # 4位年+年/月/日 且后无章节语义，拒绝
+        if re.match(r"^\s*\d{4}\s*年", t):
+            return False
+    return True

--- a/webserver/toolbox/epub_beautify.py
+++ b/webserver/toolbox/epub_beautify.py
@@ -62,7 +62,7 @@ class EpubBeautifyTool(BaseTool):
 
     def bg_image_path(self) -> str:
         """已上传背景图（工具根目录，全局复用）。"""
-        return os.path.join(self.get_work_dir(), self._BG_NAME)
+        return os.path.join(self.get_work_dir(""), self._BG_NAME)
 
     def save_bg_image(self, data: bytes, filename: str, builtin_id: str = '') -> dict:
         """保存全书背景图：PIL 统一重编码为 JPEG（宽>1080 等比缩小）。
@@ -239,6 +239,11 @@ class EpubBeautifyTool(BaseTool):
             ids = []
         ids = list(dict.fromkeys(ids))
         total = len(ids)
+        if not total:
+            skip_task_id = self.create_task(progress_data={"status": "failed"})
+            self.complete_task(skip_task_id, error_message=_("未提供有效的书籍 ID"))
+            EpubBeautifyTool._last_task_id = skip_task_id
+            return
 
         if not EpubBeautifyTool._run_lock.acquire(blocking=False):
             # 静默跳过会让前端永远轮询不到任务（卡"处理中"），落一条失败任务
@@ -252,11 +257,6 @@ class EpubBeautifyTool(BaseTool):
                 "[EpubBeautifyTool] Already running, skipping run for ids=%s [uid:%d]",
                 ids, user_id,
             )
-            return
-        if not total:
-            skip_task_id = self.create_task(progress_data={"status": "failed"})
-            self.complete_task(skip_task_id, error_message=_("未提供有效的书籍 ID"))
-            EpubBeautifyTool._last_task_id = skip_task_id
             return
 
         task_id = None

--- a/webserver/toolbox/epub_beautify_lib.py
+++ b/webserver/toolbox/epub_beautify_lib.py
@@ -154,14 +154,35 @@ def _write_zip(entries: dict, out_path: str) -> None:
 
 
 def _decode(data: bytes) -> str:
-    """UTF-8 优先，失败用检测器兜底（复用 text_replace 思路的简化版）。"""
+    """UTF-8 优先，失败用编码检测（支持 GBK/Big5/Shift_JIS 等），并重写 XML 声明为 utf-8。"""
     try:
         return data.decode('utf-8')
     except UnicodeDecodeError:
+        # 复用 txt 编码修复的检测器，对 GBK/Big5 做可读性打分择优，避免 Big5 被 gb18030 静默错译
         try:
-            return data.decode('gb18030')
-        except UnicodeDecodeError:
-            return data.decode('utf-8', errors='replace')
+            from .encoding_detect import decode_with_report
+            text, report = decode_with_report(data)
+            if not report.get('garbage') and not report.get('unrecoverable'):
+                if text.lstrip().startswith('<?xml'):
+                    text = re.sub(r"""(<\?xml[^>]*encoding\s*=\s*)["'][^"']*["']""", r'\1"utf-8"', text, count=1, flags=re.IGNORECASE)
+                return text
+        except Exception:
+            pass
+        # 回退：依次尝试 GB18030 / Big5，择优或兜底
+        for enc in ('gb18030', 'big5'):
+            try:
+                text = data.decode(enc)
+                if text.lstrip().startswith('<?xml'):
+                    text = re.sub(r"""(<\?xml[^>]*encoding\s*=\s*)["'][^"']*["']""", r'\1"utf-8"', text, count=1, flags=re.IGNORECASE)
+                return text
+            except UnicodeDecodeError:
+                continue
+        text = data.decode('utf-8', errors='replace')
+        if text.lstrip().startswith('<?xml'):
+            text = re.sub(r"""(<\?xml[^>]*encoding\s*=\s*)["'][^"']*["']""", r'\1"utf-8"', text, count=1, flags=re.IGNORECASE)
+        return text
+
+
 
 
 # ── OPF 解析 ──────────────────────────────────────────────────────────────────
@@ -431,7 +452,8 @@ def _prune_nav_bytes(data: bytes) -> tuple:
     pruned = 0
 
     def _li_text(li):
-        a = li.find(_q('a', _NS_XHTML))
+        # 兼容包裹型：<li><span><a> 等深层嵌套
+        a = li.find('.//' + _q('a', _NS_XHTML))
         return ''.join(a.itertext()).strip() if a is not None else ''
 
     def _clean_ol(ol):
@@ -510,7 +532,7 @@ def _build_toc_page(toc_items: list, ref_dir: str, truncated: bool = False,
             td_cls = ' class="mb-toc-l2"' if lv == 'lv2' else ''
             entries.append(
                 '<tr><td%s><a href="%s">%s %s</a></td>'
-                '<td class="mb-toc-mark">\\　✦</td></tr>'
+                '<td class="mb-toc-mark">　✦</td></tr>'
                 % (td_cls, rel, num_span, _esc(title))
             )
         else:
@@ -572,13 +594,17 @@ def _looks_like_title(text: str) -> bool:
 
 
 def _add_class(attrs: str, cls: str) -> str:
-    """给开标签属性串追加 class（已含 class 则合并）。"""
-    m = re.search(r'\bclass\s*=\s*"([^"]*)"', attrs)
+    """给开标签属性串追加 class（已含 class 则合并，兼容单/双引号）。"""
+    m = re.search(r'''\bclass\s*=\s*(?:"([^"]*)"|'([^']*)')''', attrs)
     if m:
-        existing = m.group(1)
+        # 兼容双引号与单引号两种写法
+        existing = m.group(1) if m.group(1) is not None else m.group(2)
         if cls in existing.split():
             return attrs
-        return attrs[:m.start(1)] + (existing + ' ' + cls) + attrs[m.end(1):]
+        # 统一回写为双引号，避免重复 class 属性
+        new_val = (existing + ' ' + cls).strip()
+        # 替换整个 class=... 为双引号形式
+        return attrs[:m.start()] + ' class="%s"' % new_val + attrs[m.end():]
     return attrs + ' class="%s"' % cls
 
 
@@ -699,7 +725,7 @@ def mark_chapters_in_html(html_str: str, split_title: bool = False) -> tuple:
     :return: (new_html, stats)，stats = {'chapters','volumes','splits'}
     """
     empty = {'chapters': 0, 'volumes': 0, 'splits': 0}
-    if 'mb-ch' in html_str or '<html' not in html_str.lower():
+    if ('mb-ch' in html_str or 'mb-vol' in html_str) or '<html' not in html_str.lower():
         return html_str, dict(empty)
     if _FRONT_TYPE_RE.search(html_str[:4000]):
         return html_str, dict(empty)
@@ -707,6 +733,16 @@ def mark_chapters_in_html(html_str: str, split_title: bool = False) -> tuple:
     stats = dict(empty)
     first_done = False
     heading_seen = False
+    # 性能护栏：开闭不齐的大文件跳过块级正则（避免 _BLOCK_RE O(n²) 退化）
+    if len(html_str) > 80000:
+        # 粗略统计 p 标签开闭数，不匹配且文件较大则跳过标记（与 analyze 的 p_close_mismatch 思路一致）
+        try:
+            _open = len(re.findall(r'<p\b', html_str, re.IGNORECASE))
+            _close = len(re.findall(r'</p>', html_str, re.IGNORECASE))
+            if _open != _close and max(_open, _close) > 50:
+                return html_str, dict(empty)
+        except Exception:
+            pass
 
     def _handle_block(tag, attrs, inner, is_div=False):
         nonlocal stats, heading_seen, first_done
@@ -748,6 +784,8 @@ def mark_chapters_in_html(html_str: str, split_title: bool = False) -> tuple:
             return '<%s%s>%s</%s>%s' % (tag, new_attrs, inner, tag,
                                         '' if is_volume else _MB_SEP)
         if heading_seen and not first_done and not is_div:
+            if 'data-mb-first' in (cls_attr or ''):
+                return None
             new_attrs = cls_attr + ' data-mb-first="true"'
             first_done = True
             return '<%s%s>%s</%s>' % (tag, new_attrs, inner, tag)
@@ -1064,6 +1102,8 @@ def analyze_epub(epub_path: str, sample_limit: int = 20) -> dict:
         != len(re.findall(rb'</p>', entries[t], re.IGNORECASE))
     )
     for t in text_entries:
+        if t not in entries:
+            continue
         if _is_front_file(t):
             continue
         if sampled >= sample_limit:
@@ -1166,8 +1206,11 @@ def _set_page_progression(opf_str: str, direction: str) -> str:
             tag, count=1,
         )
     else:
-        # 插到闭合符前（兼容 <spine> 与 <spine toc="ncx">）
-        new_tag = tag[:-1].rstrip() + ' page-progression-direction="%s">' % direction
+        # 插到闭合符前（兼容 <spine> 与 <spine toc="ncx"> 及自闭合 <spine/>）
+        if tag.rstrip().endswith('/>'):
+            new_tag = tag.rstrip()[:-2].rstrip() + ' page-progression-direction="%s"/>' % direction
+        else:
+            new_tag = tag[:-1].rstrip() + ' page-progression-direction="%s">' % direction
     if new_tag == tag:
         return opf_str
     return opf_str[:m.start()] + new_tag + opf_str[m.end():]
@@ -1318,7 +1361,7 @@ def beautify(
 
     if (not inbook_toc_paths or nav_semantic_in_spine) and toc_items:
         # 截断仅在显式传入 max_toc_entries 时发生（默认 None = 全量收录）
-        truncated = bool(max_toc_entries) and len(toc_items) > max_toc_entries
+        truncated = (max_toc_entries is not None) and len(toc_items) > max_toc_entries
         if truncated:
             toc_items = toc_items[:max_toc_entries]
         toc_path = ctx.opf_dir + MB_TOC_NAME
@@ -1414,6 +1457,9 @@ def beautify(
         if t not in entries:
             continue
         html = _decode(entries[t])
+        # 统一 XML 声明为 utf-8（GBK/Big5 原文件头修正，避免 utf-8 实体与声明不一致）
+        if html.lstrip().startswith('<?xml'):
+            html = re.sub(r"""(<\?xml[^>]*encoding\s*=\s*)["'][^"']*["']""", r'\1"utf-8"', html, count=1, flags=re.IGNORECASE)
         changed = False
         # 弹注/标注美化（先于章节标记执行，豁免类才能生效；目录/前置页不做）
         if notes and not _is_toc_doc(t, html) and not _is_front_file(t):

--- a/webserver/toolbox/styles/__init__.py
+++ b/webserver/toolbox/styles/__init__.py
@@ -92,7 +92,7 @@ def _interpolate(template: str, params: dict, use_system_fonts: bool,
 
 # ── 自定义配色与全书底色────────────────────────────────────────────
 _HEX_RE = re.compile(r'^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$')
-_PALETTE_KEYS = ('accent', 'accent_light', 'muted', 'border', 'quote_bg', 'code_bg')
+_PALETTE_KEYS = ('accent', 'accent_light', 'accent_dark', 'muted', 'border', 'quote_bg', 'code_bg', 'toc_gradient')
 
 
 def _blend_hex(color: str, target_rgb: tuple, ratio: float) -> str:
@@ -294,13 +294,21 @@ def get_preset_css(preset_id: str, use_system_fonts: bool = True,
         toc_css = _interpolate(f.read(), params, use_system_fonts, font_overrides)
     template = template.replace("{{TOC_STYLE}}", toc_css)
 
-    # 响应式与特殊元素补齐
+    # 响应式与特殊元素补齐：注入点统一前置（避免末尾注入的 responsive 覆盖各预设主题色长线；vertclassical 已前置验证正确）
     responsive_path = os.path.join(_PRESETS_DIR, "responsive.css")
     if os.path.exists(responsive_path):
         with open(responsive_path, encoding="utf-8") as f:
             responsive_css = _interpolate(f.read(), params, use_system_fonts, font_overrides)
         if "{{RESPONSIVE}}" in template:
-            template = template.replace("{{RESPONSIVE}}", responsive_css)
+            # 移除原占位符，统一前置到 @page 之后或文件头部，保证预设自身规则层叠胜出
+            template = template.replace("{{RESPONSIVE}}", "")
+            # 插到 @page 块之后（若有），否则直接前置
+            _m = re.search(r'@page\s*\{[^}]*\}', template)
+            if _m:
+                insert_at = _m.end()
+                template = template[:insert_at] + "\n\n/* ── responsive injected (front) ── */\n" + responsive_css + template[insert_at:]
+            else:
+                template = "/* ── responsive injected (front) ── */\n" + responsive_css + "\n" + template
         else:
             template = template.rstrip() + "\n\n/* ── responsive injected ── */\n" + responsive_css
 

--- a/webserver/toolbox/styles/__init__.py
+++ b/webserver/toolbox/styles/__init__.py
@@ -168,6 +168,13 @@ def _apply_page_tint(css: str, page_tint, params: dict) -> str:
 
 _PARA_BLOCK_HEAD = '\n\n/* ── 段落排版（用户自定义：缩进/段距）── */\n'
 
+# responsive.css 对 Calibre 类汤书用 .calibre* 选择器（特异性 0-1-1，带 !important）
+# 强制 text-indent/margin，通用 `p` 规则（0-0-1）会被压制——responsive 已前置注入，
+# 末尾以同选择器列表覆写即可（同特异性按源序取胜）。段距覆写仅限段落级选择器：
+# 裸 .calibre / .calibre1 常是 body/容器元素，参与段距会造成整页漂移。
+_CALIBRE_INDENT_SELECTORS = 'p.calibre, p.calibre1, p.calibre2, div.calibre1, .calibre1, .calibre'
+_CALIBRE_MARGIN_SELECTORS = 'p.calibre, p.calibre1, p.calibre2, div.calibre1'
+
 
 def _clamp_gap(value) -> float:
     """段间距归一为 [0, 3] 的浮点 em 值；None/非法输入回落 0。"""
@@ -187,9 +194,10 @@ def _clamp_gap(value) -> float:
 def _apply_para_style(css: str, para_indent: bool = True, para_gap=None) -> str:
     """段落排版后处理（层叠序在后必胜）：
 
-    - para_indent=False → 全部段落顶格（引文块由原书更高特异性的
-      ``blockquote p`` 规则自动保留缩进）；
-    - para_gap>0 → 段落下边距取该值（em），并恢复引文内紧凑无段距。
+    - para_indent=False → 全部段落顶格（含 Calibre 类汤书：responsive 的
+      ``.calibre*`` 高特异性强制缩进由同选择器末尾覆写归零）；
+    - para_gap>0 → 段落下边距取该值（em），并恢复引文内紧凑无段距
+      （类汤书的 ``p.calibre*`` 段落同步覆写 margin）。
     均为默认时原样返回，保证存量输出零变化。
     """
     gap = _clamp_gap(para_gap)
@@ -206,6 +214,22 @@ def _apply_para_style(css: str, para_indent: bool = True, para_gap=None) -> str:
     if gap > 0:
         p_rules.append('    margin: 0 0 %sem 0 !important;' % ('%g' % gap))
     block = _PARA_BLOCK_HEAD + 'p {\n' + '\n'.join(p_rules) + '\n}'
+
+    # Calibre 类汤书兜底：responsive.css 的 .calibre* 规则（0-1-1）会压制上文
+    # 通用 p 规则（0-0-1），导致顶格/段距开关在该类书上失效——同选择器覆写
+    if indent_off:
+        block += (
+            '\n%s {\n'
+            '    text-indent: 0 !important;\n'
+            '    duokan-text-indent: 0 !important;\n'
+            '}' % _CALIBRE_INDENT_SELECTORS
+        )
+    if gap > 0:
+        block += (
+            '\n%s {\n'
+            '    margin: 0 0 %sem 0 !important;\n'
+            '}' % (_CALIBRE_MARGIN_SELECTORS, '%g' % gap)
+        )
 
     # 缩进仍开启且调整了段距时，章首段顶格需重申（否则被上面的通用规则覆盖）
     if not indent_off:

--- a/webserver/toolbox/toolset.py
+++ b/webserver/toolbox/toolset.py
@@ -1,7 +1,7 @@
 """
 工具管理类，所有工具进行注册
 
-@author: PoxenStudio, 2026
+@author: shiningsprk-arch, 2026
 """
 
 
@@ -99,11 +99,16 @@ class ToolSet:
         from .author_clean_tool import AuthorCleanTool
         from .mimo_tts import MimoTTSTool
         from .bookbarn_acceptor_tool import BookBarnAcceptorTool
-        from .curie_tool import CurieTool
+        from .text_replace import TextReplaceTool
+        from .txt_encoding_fixer import TxtEncodingFixerTool
+        from .chinese_converter_tool import ChineseConverterTool
         from .epub_beautify import EpubBeautifyTool
 
         ToolSet.register(MergeFormatsTool.info())
         ToolSet.register(ReviewBookLanguageTool.info())
+        ToolSet.register(TextReplaceTool.info())
+        ToolSet.register(TxtEncodingFixerTool.info())
+        ToolSet.register(ChineseConverterTool.info())
         ToolSet.register(MinifyPdfTool.info())
         ToolSet.register(TextProcessor.info())
         ToolSet.register(FormatsPruningTool.info())
@@ -113,7 +118,6 @@ class ToolSet:
         ToolSet.register(MimoTTSTool.info())
         ToolSet.register(RareBookDownloader.info())
         ToolSet.register(BookBarnAcceptorTool.info())
-        ToolSet.register(CurieTool.info())
         ToolSet.register(EpubBeautifyTool.info())
 
         MinifyPdfTool.cleanup_old_files()


### PR DESCRIPTION
### 变更

- **移除误提交 Curie**：删除 	oolset.py/handlers/toolbox.py 对 curie_tool 的导入、注册及 7 条 /api/toolbox/curie/* 路由（本地 curie-tool/ 保留不入仓）
- **恢复误删三工具**：还原 da7f29a7 误删的正文替换 / TXT 编码修复 / 繁简转换（TextReplace/TxtEncodingFixer/ChineseConverter 注册 + 8 路由，前端 *.vue 已在仓）
- **修复 P1-5 编码**：epub_beautify_lib._decode 复用 encoding_detect 打分择优（gb18030/ig5 不再静默错译），并统一重写 <?xml encoding> 为 utf-8
- **收敛 Banner**：epub_beautify.vue:1816 由 ixed 全视口改为 sticky 容器内吸底，限制在工具箱部分内
- **同步修复 P1-P3 余下问题**（死锁、_add_class 单引号、幂等 mb-vol/data-mb-first、性能护栏、_li_text 深搜、esponsive 前置、chapter_patterns 裸数字、max_toc/spine/seal、轮询/预览竞态/	uneSummary 等）

py_compile 通过，	ests/test_epub_beautify_core.py 87/87 绿。