### PR TITLE
fix(toolbox): 去除 AdminEpubBeautifyPreview 重复 @js 装饰器

### DIFF
--- a/webserver/handlers/toolbox.py
+++ b/webserver/handlers/toolbox.py
@@ -827,7 +827,6 @@ class AdminTextReplaceProgress(BaseHandler):
 
 class AdminEpubBeautifyPreview(BaseHandler):
     @js
-    @js
     @is_admin
     def post(self):
         data = tornado.escape.json_decode(self.request.body)


### PR DESCRIPTION
## 问题

`webserver/handlers/toolbox.py` 的 `AdminEpubBeautifyPreview` 挂了两个 `@js`：

```python
class AdminEpubBeautifyPreview(BaseHandler):
    @js
    @js          # ← 多余的一层
    @is_admin
    def post(self):
```

装饰顺序自下而上，真实 `post()` 被内层 `@js` 包裹后又被外层 `@js` 再包一层。`@js` 的实现（`handlers/base.py`）负责 `self.write(rsp)` + `self.finish()`，于是每次请求的执行流为：

1. 外层 `@js` await 内层 `@js`；
2. 内层完成业务逻辑 → `write(结果JSON)` → `finish()`——**响应在此已完成**；
3. 内层返回 `None`，外层把 `None` 当作"未写响应"，继续 `write({})`；
4. `finish()` 已调用，Tornado 抛出 `RuntimeError: write() after finish()`。该行位于外层 `@js` 的 try 块之外，成为未捕获异常，由 Tornado 记录完整堆栈。

## 影响

- 客户端仍能收到第 2 步写出的正确 JSON，**UI 无感知**（这也是该问题一直未被察觉的原因）；
- 但每次调用 `/api/toolbox/epub_beautify/preview`（打开 EPUB 美化页选中书籍时触发）都会在服务端日志新增一条 ERROR 级未处理异常 + 完整堆栈，持续产生噪音、淹没真实错误，接入异常告警的环境会持续误报。

## 修复

删除多余的一个 `@js`，恢复标准单层装饰（1 行删除，无其他改动）。

## 验证

- `py_compile` 通过；
- 装饰链人工推演见上；
- 该 handler 在本 PR 之前的单 `@js` 版本工作正常（双层为后续提交引入）。

## 备注

`v4.2.0` 分支存在同样的问题（v4.2.0 自 develop 分叉时带入），建议本 PR 合并后同步到发布分支。
