### PR TITLE
信任X-Forwarded-Port，反代场景优化。

### DIFF
--- a/conf/nginx/mybooks.conf
+++ b/conf/nginx/mybooks.conf
@@ -24,6 +24,20 @@ map $request_uri $get_expires {
     default     -1s;
 }
 
+# 修复多层代理时 X-Forwarded-Host/Proto 丢失端口问题（见线上 talebook.1231431.xyz:50006 头像问题）
+map $http_x_forwarded_host $my_real_host {
+    "" $http_host;
+    default $http_x_forwarded_host;
+}
+map $http_x_forwarded_proto $my_real_proto {
+    "" $scheme;
+    default $http_x_forwarded_proto;
+}
+map $http_x_forwarded_port $my_real_port {
+    "" $server_port;
+    default $http_x_forwarded_port;
+}
+
 server {
     listen 80;
     listen 443 ssl;
@@ -161,16 +175,26 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    # 头像等静态资源不缓存，避免多层缓存导致头像更新延迟或错误（线上 NPM 的 assets.conf 会缓存 *.png 30m）
+    location ^~ /avatar/ {
+        expires -1s;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        try_files $uri $uri/ =404;
+        access_log off;
+    }
+
     location ~ ^/(api|get|read|opds|auth)/ {
         expires $get_expires;
 
         proxy_pass       http://tornado;
         proxy_redirect   off;
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $my_real_host;
+        proxy_set_header X-Forwarded-Proto $my_real_proto;
+        proxy_set_header X-Forwarded-Port $my_real_port;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Scheme $req_scheme;
+        proxy_set_header X-Scheme $my_real_proto;
         proxy_set_header X-Real-IP $remote_addr;
 
         # WebSocket support

--- a/webserver/handlers/base.py
+++ b/webserver/handlers/base.py
@@ -302,7 +302,19 @@ class BaseHandler(web.RequestHandler):
 
     def set_hosts(self):
         # site_url为完整路径，用于发邮件等 — 无条件信任反代透传的 Host / Proto（见 plan 域A）
+        # 兼容多层 Nginx：优先取 X-Forwarded-Host（若含端口则直接使用），否则按 X-Forwarded-Port 补齐端口
         host = self.request.headers.get("X-Forwarded-Host", self.request.host).split(",")[0].strip()
+        # 若 Host 未带端口但上游通过 X-Forwarded-Port 单独透传端口（如 NPM 的 $server_port），则补齐
+        # 需兼容 IPv6： "[::1]" 无端口但含 ":"，"[::1]:50006" 含 "]:"
+        if host.startswith("["):
+            has_port = "]:" in host
+        else:
+            has_port = ":" in host
+        if not has_port:
+            x_port = self.request.headers.get("X-Forwarded-Port", "").split(",")[0].strip()
+            if x_port and x_port not in ("80", "443"):
+                # 仅当非标准端口时追加，避免 https://host:443 这类冗余
+                host = f"{host}:{x_port}"
         proto = self.request.headers.get("X-Forwarded-Proto", self.request.headers.get("X-Scheme", self.request.protocol)).split(",")[0].strip()
         self.site_url = proto + "://" + host
 


### PR DESCRIPTION
修复多层 Nginx 反代（NPM 等）时 X-Forwarded-Host 丢失端口导致 avatar 等以 site_url 拼装的绝对 URL 缺少非标端口问题。新增 my_real_host/proto/port 透传，avatar location 禁缓存，base.py 兼容 IPv6 的 port 补齐。线上非标端口反代场景已验证。