### PR TITLE
fix(toolbox): epub_beautify 复审修复（命名空间/标注白名单/无链接目录页/幂等）

### DIFF
--- a/app/src/pages/toolbox/epub_beautify.vue
+++ b/app/src/pages/toolbox/epub_beautify.vue
@@ -1147,7 +1147,10 @@ export default {
               return s;
             });
           }
-          if (this.presets.length > 0) this.preset = this.presets[0].id;
+          // 仅在当前预设已失效（不在列表）时兜底——选书不应重置用户已选的风格
+          if (this.presets.length > 0 && !this.presets.some((p) => p.id === this.preset)) {
+            this.preset = this.presets[0].id;
+          }
           this.applyCleanupRecommendations();
         } else {
           this.analysisError = rsp.msg || rsp.err;

--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -2999,3 +2999,184 @@ class TestTocParentDirHrefs(unittest.TestCase):
                     os.remove(p)
 
 
+# ── 2026-09-08 复审修复回归 ────────────────────────────────────────────────────
+
+class TestReviewFixes20260908(unittest.TestCase):
+    """复审修复回归：epub 命名空间声明 / 标注样式白名单对齐 / 无链接纯文本
+    目录页 / li 标题分隔符 / 标题计数口径。"""
+
+    PLAIN_TOC_ROWS = "".join(
+        '<p class="calibre1">第%s章 标题%s</p>' % (n, n) for n in
+        ["一", "二", "三", "四", "五", "六", "七", "八", "九", "十", "十一", "十二"])
+
+    # ── P1-a：注入 epub:type 前必须声明 xmlns:epub（否则整份文档非良构）──
+
+    def test_notes_declares_epub_namespace(self):
+        for name in ("NOTES_CH_A", "NOTES_CH_B", "NOTES_CH_G"):
+            src = globals()[name]
+            new, _ = lib.mark_notes_in_html(src)
+            self.assertIn('xmlns:epub="http://www.idpf.org/2007/ops"', new, name)
+            ET.fromstring(new)  # 未绑定前缀会抛 ParseError
+            twice, _ = lib.mark_notes_in_html(new)
+            self.assertEqual(twice.count("xmlns:epub"), 1, name)  # 幂等
+
+    def test_notes_namespace_not_duplicated_when_present(self):
+        src = NOTES_CH_B.replace(
+            '<html xmlns="http://www.w3.org/1999/xhtml"',
+            '<html xmlns="http://www.w3.org/1999/xhtml" '
+            'xmlns:epub="http://www.idpf.org/2007/ops"')
+        new, _ = lib.mark_notes_in_html(src)
+        self.assertEqual(new.count("xmlns:epub"), 1)
+        ET.fromstring(new)
+
+    def test_notes_wellformed_for_class_only_source(self):
+        """源文件无任何 epub: 属性的 B 型书（calibre 导出形态）：归一化后仍良构。"""
+        src = ('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head>'
+               '<body><p>正文<a class="footnote" href="#n1">1</a>。</p>'
+               '<ol class="footnote-content"><li class="footnote-item" id="n1">注文。</li></ol>'
+               '</body></html>')
+        new, st = lib.mark_notes_in_html(src, normalize=True)
+        self.assertEqual(st["wrapped"], 1)
+        self.assertIn('epub:type="noteref"', new)
+        ET.fromstring(new)
+
+    def test_notes_no_namespace_when_normalize_off(self):
+        """normalize=False 不注入 epub: 属性，也就无需补声明（行为不变）。"""
+        new, _ = lib.mark_notes_in_html(NOTES_CH_B, normalize=False)
+        self.assertNotIn("xmlns:epub", new)
+
+    # ── P1-b：前端每个标注选项都必须通过 lib 校验（zhu 曾漏在白名单外）──
+
+    def test_frontend_note_mark_options_are_valid(self):
+        vue = os.path.join(TESTS_DIR, "..", "app", "src", "pages",
+                           "toolbox", "epub_beautify.vue")
+        if not os.path.exists(vue):
+            self.skipTest("vue 页面不可见（独立测试环境）")
+        with io.open(vue, encoding="utf-8") as f:
+            src = f.read()
+        block = src[src.index("noteMarkItems()"):][:2000]
+        values = re.findall(r"value:\s*'([^']+)'", block)
+        self.assertIn("zhu", values)
+        self.assertGreaterEqual(len(values), 9)
+        for v in values:
+            lib.validate_note_mark(v)
+
+    def test_handler_reuses_lib_validator(self):
+        """handler 必须复用 lib 校验（防白名单再次漂移出 zhu 这类漏项）。"""
+        path = os.path.join(TESTS_DIR, "..", "webserver", "handlers", "toolbox.py")
+        if not os.path.exists(path):
+            self.skipTest("handler 源码不可见")
+        with io.open(path, encoding="utf-8") as f:
+            src = f.read()
+        self.assertIn("validate_note_mark as eb_validate_note_mark", src)
+        self.assertNotIn('note_mark not in ("sym", "num")', src)
+
+    # ── P2：无链接纯文本目录页 ──
+
+    def _plain_toc_html(self, title="目录", tail=""):
+        return ('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>%s</title>'
+                '</head><body>%s%s</body></html>') % (title, self.PLAIN_TOC_ROWS, tail)
+
+    def _build_plain_toc_epub(self, path):
+        opf = (
+            '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            '<metadata><dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">无链接目录书</dc:title></metadata>'
+            '<manifest>'
+            '<item id="t" href="part0003.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"/>'
+            '</manifest>'
+            '<spine><itemref idref="t"/><itemref idref="c1"/></spine></package>'
+        )
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+            zf.writestr("META-INF/container.xml", CONTAINER)
+            zf.writestr("OEBPS/content.opf", opf)
+            zf.writestr("OEBPS/part0003.xhtml", self._plain_toc_html())
+            zf.writestr("OEBPS/ch1.xhtml", CH1)
+
+    def test_plain_text_toc_detected(self):
+        html = self._plain_toc_html()
+        self.assertTrue(lib._is_toc_doc("OEBPS/part0003.xhtml", html))
+        is_toc, nav = lib._classify_toc_entry("OEBPS/part0003.xhtml",
+                                             html.encode("utf-8"))
+        self.assertTrue(is_toc)
+        self.assertFalse(nav)
+
+    def test_plain_text_toc_page_not_chapter_marked(self):
+        tmp = os.path.join(TESTS_DIR, "_tmp_plain_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_plain_out.epub")
+        self._build_plain_toc_epub(tmp)
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            stats = lib.beautify(tmp, out, css)
+            with zipfile.ZipFile(out) as zf:
+                toc = zf.read("OEBPS/part0003.xhtml").decode("utf-8")
+                ch1 = zf.read("OEBPS/ch1.xhtml").decode("utf-8")
+            self.assertNotIn('class="mb-ch"', toc)
+            self.assertNotIn("mb-ch-sep", toc)
+            self.assertIn("mb-toc-page", toc)   # 目录页装饰路径生效
+            self.assertIn("mb-toc-end", toc)
+            self.assertIn("mb-ch", ch1)         # 真章节页不受影响
+            self.assertEqual(stats["marked_headers"], 2)
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_plain_toc_negative_with_long_prose(self):
+        html = self._plain_toc_html(tail='<p>%s</p>' % ("正文" * 60))
+        self.assertFalse(lib._looks_like_plain_toc(html))
+        self.assertFalse(lib._is_toc_doc("OEBPS/part0003.xhtml", html))
+
+    def test_plain_toc_negative_without_title(self):
+        self.assertFalse(lib._looks_like_plain_toc(self._plain_toc_html(title="无名页")))
+
+    def test_plain_toc_negative_when_prose_dilutes_rows(self):
+        prose = "".join('<p>%s</p>' % ("短句" * 8) for _ in range(12))
+        html = ('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>目录</title>'
+                '</head><body>%s%s</body></html>') % (self.PLAIN_TOC_ROWS, prose)
+        self.assertFalse(lib._looks_like_plain_toc(html))
+
+    # ── P3：li 标题不插块级分隔符 ──
+
+    def test_li_heading_has_no_sep_div(self):
+        html = ('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head>'
+                '<body><ul><li>第一章 列表标题</li></ul>'
+                '<h1>第二章 正文标题</h1><p>正文。</p></body></html>')
+        new, mk = lib.mark_chapters_in_html(html)
+        self.assertEqual(mk["chapters"], 2)
+        li_part = new[new.index("<ul>"):new.index("</ul>")]
+        self.assertIn("mb-ch", li_part)
+        self.assertNotIn("<div", li_part)   # ul 内不得出现块级 div
+        self.assertIn('<div class="mb-ch-sep"></div>', new)  # 非 li 标题仍有长线
+
+    # ── 小项：标题计数口径不重复 ──
+
+    def test_text_headings_excludes_h_tags(self):
+        tmp = os.path.join(TESTS_DIR, "_tmp_hcount.epub")
+        files = {
+            "OEBPS/content.opf": (
+                '<?xml version="1.0"?>'
+                '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+                '<metadata><dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">计数书</dc:title></metadata>'
+                '<manifest><item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"/></manifest>'
+                '<spine><itemref idref="c1"/></spine></package>'),
+            "OEBPS/ch1.xhtml": (
+                '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head>'
+                '<body><h1>第一章 标题</h1><p>正文。</p>'
+                '<p>第二章 标题</p><p>正文。</p></body></html>'),
+        }
+        with zipfile.ZipFile(tmp, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip",
+                        compress_type=zipfile.ZIP_STORED)
+            zf.writestr("META-INF/container.xml", CONTAINER)
+            for name, data in files.items():
+                zf.writestr(name, data)
+        try:
+            a = lib.analyze_epub(tmp)
+            self.assertEqual(a["heading_stats"]["h1"], 1)
+            self.assertEqual(a["text_headings"], 1)  # 仅 <p> 标题，不与 h1 重复
+        finally:
+            if os.path.exists(tmp):
+                os.remove(tmp)

--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -2614,6 +2614,15 @@ class TestStripHardening(unittest.TestCase):
         self.assertIn('class="calibre1"', out)
         self.assertNotIn('mb-ch"', out)
 
+    def test_strip_whitespace_idempotent(self):
+        """空白幂等：无标记时逐字原样返回（此前每跑一次多一个空格，
+        重复美化会在每个 class 属性前累积空白）。"""
+        for html in ('<p class="calibre1">正文</p><body class="mb-toc-page">',
+                     "<p class='a b'>x</p>"):
+            once = lib._strip_chapter_marks(html)
+            self.assertEqual(once, html)
+            self.assertEqual(lib._strip_chapter_marks(once), once)
+
 
 # ── 目录页三层信号 / 防炸页安全阀 / NCX 驱动打标（2026-09-06 批 2 复验）──
 # 通用篇名 + 跨文件链接（calibre 拆分书形态）：形态比例必然失效，仅密度信号可判
@@ -3040,6 +3049,16 @@ class TestReviewFixes20260908(unittest.TestCase):
         self.assertIn('epub:type="noteref"', new)
         ET.fromstring(new)
 
+    def test_notes_namespace_skips_html_in_comment(self):
+        """注释里的 <html…> 不是根元素：声明必须落在真根上。"""
+        src = ('<!-- <html> --><html xmlns="http://www.w3.org/1999/xhtml"><body>'
+               '<p>正文<a class="footnote" href="#n1">1</a>。</p>'
+               '<ol class="footnote-content"><li class="footnote-item" id="n1">注。</li></ol>'
+               '</body></html>')
+        new, _ = lib.mark_notes_in_html(src)
+        self.assertIn('<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub=', new)
+        ET.fromstring(new)
+
     def test_notes_no_namespace_when_normalize_off(self):
         """normalize=False 不注入 epub: 属性，也就无需补声明（行为不变）。"""
         new, _ = lib.mark_notes_in_html(NOTES_CH_B, normalize=False)
@@ -3150,6 +3169,26 @@ class TestReviewFixes20260908(unittest.TestCase):
         self.assertIn("mb-ch", li_part)
         self.assertNotIn("<div", li_part)   # ul 内不得出现块级 div
         self.assertIn('<div class="mb-ch-sep"></div>', new)  # 非 li 标题仍有长线
+
+    # ── 重复美化：逐条目字节一致（含空白/命名空间声明/注册幂等）──
+
+    def test_beautify_byte_idempotent(self):
+        tmp = os.path.join(TESTS_DIR, "_tmp_idem_src.epub")
+        o1 = os.path.join(TESTS_DIR, "_tmp_idem_1.epub")
+        o2 = os.path.join(TESTS_DIR, "_tmp_idem_2.epub")
+        build_notes_epub(tmp)
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            lib.beautify(tmp, o1, css, notes=True, note_mark="zhu")
+            lib.beautify(o1, o2, css, notes=True, note_mark="zhu")
+            with zipfile.ZipFile(o1) as a, zipfile.ZipFile(o2) as b:
+                self.assertEqual(a.namelist(), b.namelist())
+                for name in a.namelist():
+                    self.assertEqual(a.read(name), b.read(name), name)
+        finally:
+            for p in (tmp, o1, o2):
+                if os.path.exists(p):
+                    os.remove(p)
 
     # ── 小项：标题计数口径不重复 ──
 

--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -3059,6 +3059,22 @@ class TestReviewFixes20260908(unittest.TestCase):
         self.assertIn('<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub=', new)
         ET.fromstring(new)
 
+    def test_legacy_output_namespace_repaired(self):
+        """旧版缺陷输出（已带 mb-notemark 但缺 xmlns:epub）再美化时补声明。"""
+        legacy = ('<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                  '<p>正文<a class="footnote mb-notemark" epub:type="noteref" '
+                  'href="#n1">1</a>。</p>'
+                  '<ol class="footnote-content mb-notes">'
+                  '<li class="footnote-item mb-note-item" id="n1">注。</li></ol>'
+                  '</body></html>')
+        new, st = lib.mark_notes_in_html(legacy)
+        self.assertEqual(st, {'refs': 0, 'items': 0, 'normalized': 0, 'wrapped': 0})
+        self.assertIn("xmlns:epub", new)
+        ET.fromstring(new)
+        # 幂等：再跑一次不再变化
+        again, _ = lib.mark_notes_in_html(new)
+        self.assertEqual(again, new)
+
     def test_notes_no_namespace_when_normalize_off(self):
         """normalize=False 不注入 epub: 属性，也就无需补声明（行为不变）。"""
         new, _ = lib.mark_notes_in_html(NOTES_CH_B, normalize=False)

--- a/webserver/handlers/toolbox.py
+++ b/webserver/handlers/toolbox.py
@@ -31,6 +31,7 @@ from webserver.toolbox.chinese_converter_tool import ChineseConverterTool, DIREC
 from webserver.toolbox.bookbarn_acceptor_tool import BookBarnAcceptorTool
 from webserver.toolbox.epub_beautify import EpubBeautifyTool
 from webserver.toolbox.utils.styles import TOC_STYLES as EB_TOC_STYLES, list_presets as eb_list_presets
+from webserver.toolbox.utils.epub_beautify_lib import validate_note_mark as eb_validate_note_mark
 from webserver.services.background_service import BackgroundTask
 
 CONF = get_settings()
@@ -1183,8 +1184,11 @@ class AdminEpubBeautifyRun(BaseHandler):
         # 弹注/标注美化（默认关）+ 标注样式（orig/sym/num/svg:<模板>）
         notes_on = bool(data.get("notes", False))
         note_mark = data.get("note_mark") or "orig"
-        _svg_ok = note_mark.startswith("svg:") and len(note_mark) > 4
-        if note_mark != "orig" and note_mark not in ("sym", "num") and not _svg_ok:
+        try:
+            # 复用 lib 唯一事实源校验（此前 handler 自维护白名单漏掉 zhu，
+            # 前端「注字圆章」选项 100% 报参数错误）
+            eb_validate_note_mark(note_mark)
+        except ValueError:
             return {"err": "params.invalid", "msg": _("未知标注样式：%s") % note_mark}
         # 背景图片开关（与前端 bg_image 一致）
         bg_image = bool(data.get("bg_image", False))

--- a/webserver/toolbox/epub_beautify.py
+++ b/webserver/toolbox/epub_beautify.py
@@ -119,7 +119,7 @@ class EpubBeautifyTool(BaseTool):
             "tool_id": "epub_beautify",
             "name": "EPUB美化",
             "description": "美化 EPUB 的目录、章节名与字体排版（12 套风格预设 × 4 种目录形式，含竖排右翻古籍；卷章分级、双行排版、对话行点缀；支持批量队列与全书底色/自定义配色），生成新书",
-            "revision": "0.2.0",
+            "revision": "0.2.1",
             "author": "黏菌",
             "publish_date": "2026-08-22",
         }
@@ -305,7 +305,7 @@ class EpubBeautifyTool(BaseTool):
                 return
             if notes:
                 try:
-                    epub_beautify_lib._validate_note_mark(note_mark or 'orig')
+                    epub_beautify_lib.validate_note_mark(note_mark or 'orig')
                 except ValueError as err:
                     error_message = _("标注样式不合法：%s") % err
                     logging.error("[EpubBeautifyTool] Bad note_mark %r [uid:%d]", note_mark, user_id)

--- a/webserver/toolbox/utils/epub_beautify_lib.py
+++ b/webserver/toolbox/utils/epub_beautify_lib.py
@@ -954,19 +954,22 @@ def _strip_chapter_marks(html_str: str) -> str:
     """移除误打在目录页上的章节标记（mb-ch/mb-vol/mb-ch-split 类 + 长线 div）。
 
     正常流程不给目录页打标，页面上的标记只能来自旧版检测缺陷，剥离即修复。
-    幂等：无标记时原样返回；类名剥空时整个 class 属性移除，不留 class=""。
+    幂等：无标记时逐字原样返回（class 的前导空白一并捕获后原样回写——此前
+    回写固定带一个前导空格，每跑一次每个 class 属性就多一个空格）；
+    类名剥空时整个 class 属性（连同前导空白）移除，不留 class=""。
     单双引号两种写法均处理（自家注入为双引号，手写单引号书亦兼容）。"""
     out = _MB_SEP_DIV_RE.sub('', html_str)
 
     def _fix_class(m):
+        lead = m.group(1)
+        val = m.group(2) if m.group(2) is not None else m.group(3)
         quote = '"' if '"' in m.group(0) else "'"
-        val = m.group(1) if m.group(1) is not None else m.group(2)
         tokens = [t for t in val.split() if t not in _CH_MARK_TOKENS]
         if not tokens:
             return ''
-        return ' class=%s%s%s' % (quote, ' '.join(tokens), quote)
+        return '%sclass=%s%s%s' % (lead, quote, ' '.join(tokens), quote)
 
-    return re.sub(r'''class\s*=\s*(?:"([^"]*)"|'([^']*)')''', _fix_class, out)
+    return re.sub(r'''(\s*)class\s*=\s*(?:"([^"]*)"|'([^']*)')''', _fix_class, out)
 
 
 def _mark_toc_page_body(html_str: str) -> str:
@@ -1412,26 +1415,32 @@ def _add_epub_type_noteref(attrs: str) -> str:
 # 默认 XHTML 命名空间，直接写 epub:type 会让整份内容文档变成非良构 XML
 # （未绑定前缀是致命解析错误），严格阅读器/EPUBCheck 会判整章不可读。
 _EPUB_NS_ATTR = 'xmlns:epub="http://www.idpf.org/2007/ops"'
-_HTML_TAG_RE = re.compile(r'<html\b[^>]*>', re.I)
+_HTML_TAG_RE = re.compile(r'<!--[\s\S]*?-->|<html\b[^>]*>', re.I)
 
 
 def _ensure_epub_ns(html_str: str) -> str:
     """确保 <html> 根声明 epub 前缀（幂等；无 <html> 标签时原样返回）。
 
     已用别的前缀绑定同一命名空间（如 xmlns:ops）时仍补 epub: ——同一命名
-    空间允许多前缀绑定，而注入用的就是 epub: 前缀。
+    空间允许多前缀绑定，而注入用的就是 epub: 前缀。注释里的 ``<html…>``
+    不是根元素，跳过继续向后找（否则声明会被写进注释而依然未绑定）。
     """
-    m = _HTML_TAG_RE.search(html_str)
-    if not m:
-        return html_str
-    tag = m.group(0)
-    if re.search(r'xmlns:epub\s*=', tag, re.I):
-        return html_str
-    if tag.rstrip().endswith('/>'):
-        new_tag = tag.rstrip()[:-2].rstrip() + ' %s/>' % _EPUB_NS_ATTR
-    else:
-        new_tag = tag[:-1].rstrip() + ' %s>' % _EPUB_NS_ATTR
-    return html_str[:m.start()] + new_tag + html_str[m.end():]
+    pos = 0
+    while True:
+        m = _HTML_TAG_RE.search(html_str, pos)
+        if not m:
+            return html_str
+        tag = m.group(0)
+        if tag.startswith('<!--'):
+            pos = m.end()
+            continue
+        if re.search(r'xmlns:epub\s*=', tag, re.I):
+            return html_str
+        if tag.rstrip().endswith('/>'):
+            new_tag = tag.rstrip()[:-2].rstrip() + ' %s/>' % _EPUB_NS_ATTR
+        else:
+            new_tag = tag[:-1].rstrip() + ' %s>' % _EPUB_NS_ATTR
+        return html_str[:m.start()] + new_tag + html_str[m.end():]
 
 
 def mark_notes_in_html(html_str: str, normalize: bool = True,

--- a/webserver/toolbox/utils/epub_beautify_lib.py
+++ b/webserver/toolbox/utils/epub_beautify_lib.py
@@ -1460,13 +1460,15 @@ def mark_notes_in_html(html_str: str, normalize: bool = True,
     - 条目 li 追加 ``mb-note-item`` 豁免类——章末注释不会被章节标题扫描误标。
 
     安全红线：只增不改不删（除用户显式选择的 img 替换），href/id/class 原样保留。
-    幂等：已含 mb-notemark 的文件直接原样返回。
+    幂等：已含 mb-notemark 的文件不再打标（仅按需补 xmlns:epub 声明——旧版
+    缺陷输出修复，见 _ensure_epub_ns）。
     :return: (new_html, stats)；stats = {refs, items, normalized, wrapped}
     """
     validate_note_mark(note_mark)
     empty = {'refs': 0, 'items': 0, 'normalized': 0, 'wrapped': 0}
     if 'mb-notemark' in html_str or 'mb-notes' in html_str:
-        return html_str, dict(empty)
+        # 旧版输出可能已注入 epub:type 却未声明前缀（非良构）：再美化时补上
+        return (_ensure_epub_ns(html_str) if normalize else html_str), dict(empty)
     refs_found = _NOTE_REF_RE.findall(html_str)
     items_found = _NOTE_ITEM_CNT_RE.findall(html_str)
     if not refs_found and not items_found:
@@ -2106,6 +2108,8 @@ def beautify(
                 notes_items += nstats['items']
                 notes_normalized += nstats['normalized']
                 notes_wrapped += nstats['wrapped']
+            if new_html != html:
+                # 零统计也可能有变更：旧版缺陷输出补 xmlns:epub 声明
                 changed = True
                 html = new_html
         # 内容清理（段首空格归一/空段/meta），目录页不做文本清理避免破坏布局

--- a/webserver/toolbox/utils/epub_beautify_lib.py
+++ b/webserver/toolbox/utils/epub_beautify_lib.py
@@ -842,17 +842,68 @@ def _looks_like_link_toc(html_str: str) -> bool:
     return False
 
 
+# 无链接纯文本目录页（部分制作器产出 `<p>第X章 …</p>` 列表、整页无 <a>）：
+# 文件名/nav 语义/链接密度三类信号全部失效，此前该形态直接落进章节标记，
+# page-break 把一页目录炸成 N 个单页（安全阀判别式依赖被标块含链接，无链接
+# 时恒不触发）。此处补形态信号：目录标题 + 章节行密度 + 无长正文块。
+_PLAIN_TOC_MIN_ROWS = 5        # 至少 5 个章节形态短块
+_PLAIN_TOC_LONG_BLOCK = 80     # 页内出现超长正文块即否决
+_PLAIN_TOC_SCAN = 64 * 1024    # 扫描窗口（目录页总在页首，长目录也够用）
+
+
+def _plain_toc_rows(html_str: str) -> tuple:
+    """:return: (章节形态短块数, 短块总数, 长正文块数)。"""
+    rows = shorts = longs = 0
+
+    def _acc(text):
+        nonlocal rows, shorts, longs
+        if not text:
+            return
+        if len(text) > _PLAIN_TOC_LONG_BLOCK:
+            longs += 1
+            return
+        shorts += 1
+        if chapter_patterns.paragraph_is_heading(text):
+            rows += 1
+
+    for m in _BLOCK_RE.finditer(html_str):
+        _acc(_block_text(m.group(3)))
+    for m in _SIMPLE_DIV_RE.finditer(html_str):
+        inner = m.group(2)
+        # 容器型 div（内含块级标签）：文本已由内部块统计，跳过避免重复计数
+        if re.search(r'<(?:p|div|ul|ol|li|h[1-6]|table)\b', inner, re.I):
+            continue
+        _acc(_block_text(inner))
+    return rows, shorts, longs
+
+
+def _looks_like_plain_toc(html_str: str) -> bool:
+    """无链接纯文本目录页检测（链接密度信号的兜底，analyze/beautify 共用）。
+
+    必要条件：页首块或 ``<title>`` 恰为「目录/目次/Contents」
+    （``_has_toc_title_text``）——不满足直接返回，真章节页不会被误判，
+    也让调用方在 8KB 头即可零成本短路。命中后要求页内以章节形态短块为主
+    （≥5 行、占比 ≥60%）且无长正文块：散文页/文集页的长段落一票否决。
+    """
+    if not html_str or not _has_toc_title_text(html_str):
+        return False
+    rows, shorts, longs = _plain_toc_rows(html_str[:_PLAIN_TOC_SCAN])
+    return (rows >= _PLAIN_TOC_MIN_ROWS and not longs
+            and rows * 10 >= shorts * 6)
+
+
 def _is_toc_doc(zip_path: str, html_str: str = '') -> bool:
     """判断条目是否为书内目录页：文件名（mulu/toc/nav/contents）、
-    ``<nav epub:type="toc">`` 结构、或链接列表形态（P：纯链接目录页此前
-    检测不到，会落入章节标记，mb-ch 的 page-break-before 把目录页炸成
-    多个「第x章」独立页）。"""
+    ``<nav epub:type="toc">`` 结构、链接列表形态或纯文本列表形态（P：链接
+    目录页/无链接目录页此前检测不到，会落入章节标记，mb-ch 的
+    page-break-before 把目录页炸成多个「第x章」独立页）。"""
     base = zip_path.rsplit('/', 1)[-1]
     if _TOC_FILE_RE.search(base):
         return True
     if html_str and _has_nav_toc_semantics(html_str):
         return True
-    return bool(html_str) and _looks_like_link_toc(html_str)
+    return bool(html_str) and (_looks_like_link_toc(html_str)
+                               or _looks_like_plain_toc(html_str))
 
 
 # 链接目录形态复核窗口（P1：8KB 头不足判定时按 64KB 片段复核，不全量解码；
@@ -864,7 +915,8 @@ def _classify_toc_entry(zip_path: str, raw: bytes) -> tuple:
     """单条目目录页判定（analyze 与 beautify 主流程共用，口径一致）。
 
     文件名特征零解码；nav 语义看 8KB 头；头 8KB 内链接 ≥2 时以 64KB 片段
-    复核链接目录形态（``_looks_like_link_toc``），不再全量解码——此前
+    复核链接目录形态（``_looks_like_link_toc``），无链接时按目录标题门槛
+    复核纯文本列表形态（``_looks_like_plain_toc``），不再全量解码——此前
     beautify 主流程只看头 2000/4000 字、analyze 用全量复核，两端口径不一，
     长 ``<head>`` 的目录页会 preview 报「保留原书目录」而 run 误打章节标记。
     :param raw: 条目原始字节（可为局部读取片段，≥ `_TOC_RECHECK_BYTES` 最佳）。
@@ -880,6 +932,13 @@ def _classify_toc_entry(zip_path: str, raw: bytes) -> tuple:
         probe = _decode_head(raw, raw_n=_TOC_RECHECK_BYTES,
                              out_n=_TOC_RECHECK_BYTES)
         if _looks_like_link_toc(probe):
+            is_toc = True
+    elif not is_toc and _has_toc_title_text(head):
+        # 无链接纯文本目录页兜底：标题门槛在 8KB 头即可判定（常见书零成本
+        # 短路），命中才解码 64KB 复核章节行密度
+        probe = _decode_head(raw, raw_n=_TOC_RECHECK_BYTES,
+                             out_n=_TOC_RECHECK_BYTES)
+        if _looks_like_plain_toc(probe):
             is_toc = True
     return is_toc, nav_semantic
 
@@ -1112,8 +1171,10 @@ def mark_chapters_in_html(html_str: str, split_title: bool = False) -> tuple:
             # 章题块（老转换器惯放具名锚）会被安全阀误杀
             if _INTERNAL_HREF_RE.search(inner or ''):
                 marked_with_links += 1
-            return '<%s%s>%s</%s>%s' % (tag, new_attrs, inner, tag,
-                                        '' if is_volume else _MB_SEP)
+            # 长线分隔符是块级 div：li 的父级是 ul/ol，插 div 会破坏 XHTML
+            # 内容模型（EPUBCheck 报错），li 标记不打分隔符
+            sep = '' if (is_volume or tag_l == 'li') else _MB_SEP
+            return '<%s%s>%s</%s>%s' % (tag, new_attrs, inner, tag, sep)
         if heading_seen and not first_done and not is_div:
             if 'data-mb-first' in (cls_attr or ''):
                 return None
@@ -1309,8 +1370,12 @@ NOTE_MARK_SVGS = {
 NOTE_MARK_MODES = ('orig', 'sym', 'num', 'zhu')
 
 
-def _validate_note_mark(note_mark: str) -> None:
-    """校验标注样式 id：orig/sym/num 或 svg:<模板id>；非法抛 ValueError。"""
+def validate_note_mark(note_mark: str) -> None:
+    """校验标注样式 id：orig/sym/num/zhu 或 svg:<模板id>；非法抛 ValueError。
+
+    公开入口：HTTP 层必须复用本函数，不要再维护第二份白名单——历史上
+    handler 白名单漏掉 zhu，前端选项直接 100% 报参数错误。
+    """
     if note_mark in NOTE_MARK_MODES:
         return
     if isinstance(note_mark, str) and note_mark.startswith('svg:'):
@@ -1343,6 +1408,32 @@ def _add_epub_type_noteref(attrs: str) -> str:
     return attrs.rstrip() + ' epub:type="noteref"'
 
 
+# epub 命名空间声明：注入 epub:type 的前置条件。EPUB2/calibre 导出常只声明
+# 默认 XHTML 命名空间，直接写 epub:type 会让整份内容文档变成非良构 XML
+# （未绑定前缀是致命解析错误），严格阅读器/EPUBCheck 会判整章不可读。
+_EPUB_NS_ATTR = 'xmlns:epub="http://www.idpf.org/2007/ops"'
+_HTML_TAG_RE = re.compile(r'<html\b[^>]*>', re.I)
+
+
+def _ensure_epub_ns(html_str: str) -> str:
+    """确保 <html> 根声明 epub 前缀（幂等；无 <html> 标签时原样返回）。
+
+    已用别的前缀绑定同一命名空间（如 xmlns:ops）时仍补 epub: ——同一命名
+    空间允许多前缀绑定，而注入用的就是 epub: 前缀。
+    """
+    m = _HTML_TAG_RE.search(html_str)
+    if not m:
+        return html_str
+    tag = m.group(0)
+    if re.search(r'xmlns:epub\s*=', tag, re.I):
+        return html_str
+    if tag.rstrip().endswith('/>'):
+        new_tag = tag.rstrip()[:-2].rstrip() + ' %s/>' % _EPUB_NS_ATTR
+    else:
+        new_tag = tag[:-1].rstrip() + ' %s>' % _EPUB_NS_ATTR
+    return html_str[:m.start()] + new_tag + html_str[m.end():]
+
+
 def mark_notes_in_html(html_str: str, normalize: bool = True,
                        note_mark: str = 'orig') -> tuple:
     """美化书内弹注：标注符与注释容器打标，可选语义归一化/换标记元素。
@@ -1363,7 +1454,7 @@ def mark_notes_in_html(html_str: str, normalize: bool = True,
     幂等：已含 mb-notemark 的文件直接原样返回。
     :return: (new_html, stats)；stats = {refs, items, normalized, wrapped}
     """
-    _validate_note_mark(note_mark)
+    validate_note_mark(note_mark)
     empty = {'refs': 0, 'items': 0, 'normalized': 0, 'wrapped': 0}
     if 'mb-notemark' in html_str or 'mb-notes' in html_str:
         return html_str, dict(empty)
@@ -1374,6 +1465,10 @@ def mark_notes_in_html(html_str: str, normalize: bool = True,
 
     stats = {'refs': len(refs_found), 'items': len(items_found),
              'normalized': 0, 'wrapped': 0}
+    if normalize:
+        # 注入 epub:type 前先确保 <html> 声明 epub 前缀：否则 calibre 类
+        # EPUB2 书（只声明默认 XHTML 命名空间）会整份文档非良构
+        html_str = _ensure_epub_ns(html_str)
     seq = {'n': 0}
 
     def _ref_repl(m):
@@ -1601,7 +1696,10 @@ def analyze_epub(epub_path: str, sample_limit: int = 20) -> dict:
                         leading_space_paras += 1
                     if m.group(1).lower() == 'p' and _is_dialogue_text(_block_text(inner)):
                         dialogue_paras += 1
-                    if chapter_patterns.paragraph_is_heading(_block_text(inner)):
+                    # 段落文本识别数：排除 h1-h6 块（它们已计入 heading_stats，
+                    # 否则同一标题被两个口径各计一次，前端相加后数字翻倍）
+                    if m.group(1).lower() not in ('h1', 'h2', 'h3', 'h4', 'h5', 'h6') \
+                            and chapter_patterns.paragraph_is_heading(_block_text(inner)):
                         text_headings += 1
 
             # 弹注统计（采样正文文件，防大书全量解码；健康报告与推荐徽章用，
@@ -1738,7 +1836,7 @@ def beautify(
         mark_guard_files）
     """
     if notes:
-        _validate_note_mark(note_mark)
+        validate_note_mark(note_mark)
     cleanup_n = _normalize_cleanup(cleanup)
     entries = _read_zip_entries(epub_path)
     ctx = _parse_opf(entries)


### PR DESCRIPTION
承接 #73 的复审修复（5 文件 / 3 commit）。

- **P1** 注入 `epub:type` 前补 `xmlns:epub` 声明：calibre 类 EPUB2 书此前被写成非良构 XML（整章不可读）；旧版缺陷输出再美化时自愈
- **P1** 标注样式校验改调 lib：原 handler 白名单漏 `zhu`，前端「注字圆章」100% 报参数错误
- **P2** 新增无链接纯文本目录页检测：此前整页被当章节标记，page-break 炸成 N 个单页
- **P3** `<li>` 标题不再插入块级分隔符；`_strip_chapter_marks` 空白幂等（重复美化不再累积空格）
- 小项：`text_headings` 排除 h 标签（去重复计数）；选书不再重置用户预设

测试 170 → 187（`python tests/test_epub_beautify_core.py`），含 XML 良构断言、前端选项↔lib 校验对齐、逐条目字节幂等。
