### PR TITLE
feat(toolbox): epub_beautify 目录页——无链接页替换 + 挂到封面之后

### DIFF
--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -3133,10 +3133,22 @@ class TestReviewFixes20260908(unittest.TestCase):
     def test_plain_text_toc_detected(self):
         html = self._plain_toc_html()
         self.assertTrue(lib._is_toc_doc("OEBPS/part0003.xhtml", html))
-        is_toc, nav = lib._classify_toc_entry("OEBPS/part0003.xhtml",
-                                             html.encode("utf-8"))
+        is_toc, nav, linkless = lib._classify_toc_entry(
+            "OEBPS/part0003.xhtml", html.encode("utf-8"))
         self.assertTrue(is_toc)
         self.assertFalse(nav)
+        self.assertTrue(linkless)   # 无链接 → 需替换为生成的链接目录页
+
+    def test_link_toc_not_linkless(self):
+        """可点击的链接目录页 linkless=False（保留原页，不替换）。"""
+        html = ('<html><head><title>目录</title></head><body>'
+                + "".join('<p><a href="c%02d.xhtml">第%d章 标题</a></p>' % (i, i)
+                          for i in range(1, 13)) + '</body></html>')
+        is_toc, nav, linkless = lib._classify_toc_entry(
+            "OEBPS/part0003.xhtml", html.encode("utf-8"))
+        self.assertTrue(is_toc)
+        self.assertFalse(nav)
+        self.assertFalse(linkless)
 
     def test_plain_text_toc_page_not_chapter_marked(self):
         tmp = os.path.join(TESTS_DIR, "_tmp_plain_src.epub")
@@ -3235,3 +3247,151 @@ class TestReviewFixes20260908(unittest.TestCase):
         finally:
             if os.path.exists(tmp):
                 os.remove(tmp)
+
+
+class TestLinklessTocReplacement(unittest.TestCase):
+    """无链接纯文本目录页 → 生成链接目录页并替换 spine 条目。
+
+    有 NCX/nav 数据源时替换（原页保留在包内，无损）；无数据源时退回仅样式化。
+    """
+
+    NCX = ('<?xml version="1.0" encoding="utf-8"?>'
+           '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1"><navMap>'
+           '<navPoint id="n1" playOrder="1"><navLabel><text>第一章 开端</text></navLabel>'
+           '<content src="c1.xhtml"/></navPoint>'
+           '<navPoint id="n2" playOrder="2"><navLabel><text>第二章 转折</text></navLabel>'
+           '<content src="c2.xhtml"/></navPoint>'
+           '</navMap></ncx>')
+
+    def _plain_toc_html(self):
+        rows = "".join('<p class="calibre1">第%s章 标题%s</p>' % (n, n) for n in
+                       ["一", "二", "三", "四", "五", "六",
+                        "七", "八", "九", "十", "十一", "十二"])
+        return ('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>目录</title>'
+                '</head><body>%s</body></html>') % rows
+
+    def _build(self, path, with_ncx=True, toc_html=None):
+        """封面 → 目录页 → 两章（spine 顺序固定，便于断言位置）。"""
+        manifest = (
+            '<item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="t" href="part0003.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="c2" href="c2.xhtml" media-type="application/xhtml+xml"/>')
+        spine_attr = ''
+        if with_ncx:
+            manifest += ('<item id="ncx" href="toc.ncx" '
+                         'media-type="application/x-dtbncx+xml"/>')
+            spine_attr = ' toc="ncx"'
+        opf = (
+            '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            '<metadata><dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">'
+            '无链接目录书</dc:title></metadata>'
+            '<manifest>%s</manifest>'
+            '<spine%s><itemref idref="cover"/><itemref idref="t"/>'
+            '<itemref idref="c1"/><itemref idref="c2"/></spine></package>'
+        ) % (manifest, spine_attr)
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip",
+                        compress_type=zipfile.ZIP_STORED)
+            zf.writestr("META-INF/container.xml", CONTAINER)
+            zf.writestr("OEBPS/content.opf", opf)
+            zf.writestr("OEBPS/cover.xhtml",
+                        '<html xmlns="http://www.w3.org/1999/xhtml">'
+                        '<body><h1>封面</h1></body></html>')
+            zf.writestr("OEBPS/part0003.xhtml", toc_html or self._plain_toc_html())
+            zf.writestr("OEBPS/c1.xhtml",
+                        '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                        '<p>第一章 开端</p><p>正文。</p></body></html>')
+            zf.writestr("OEBPS/c2.xhtml",
+                        '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                        '<p>第二章 转折</p><p>正文。</p></body></html>')
+            if with_ncx:
+                zf.writestr("OEBPS/toc.ncx", self.NCX)
+
+    def test_linkless_toc_replaced_by_generated(self):
+        tmp = os.path.join(TESTS_DIR, "_tmp_ll_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_ll_out.epub")
+        self._build(tmp, with_ncx=True)
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            stats = lib.beautify(tmp, out, css)
+            self.assertTrue(stats["toc_generated"])
+            self.assertEqual(stats["toc_replaced_linkless"], 1)
+            self.assertEqual(stats["toc_links_ok"], stats["toc_links_total"])
+            with zipfile.ZipFile(out) as zf:
+                names = zf.namelist()
+                opf = zf.read("OEBPS/content.opf").decode("utf-8")
+                toc = zf.read("OEBPS/mb-toc.xhtml").decode("utf-8")
+                plain = zf.read("OEBPS/part0003.xhtml").decode("utf-8")
+            # 原目录页文件保留在包内（无损红线）
+            self.assertIn("OEBPS/part0003.xhtml", names)
+            # 生成的目录页带可点击链接
+            self.assertIn('href="c1.xhtml"', toc)
+            self.assertIn('id="mb-toc"', opf)
+            # 原无链接目录页的 spine 条目被替换掉
+            self.assertNotIn('idref="t"', opf)
+            # 位置沿用原目录页在 spine 中的位置：封面之后、正文之前
+            self.assertLess(opf.index('idref="cover"'), opf.index('idref="mb-toc"'))
+            self.assertLess(opf.index('idref="mb-toc"'), opf.index('idref="c1"'))
+            # 炸页防线不回退：原无链接页仍不打章节标记
+            self.assertNotIn('class="mb-ch"', plain)
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_linkless_toc_kept_without_toc_source(self):
+        """无 NCX/nav 数据源 → 无法生成链接目录，退回仅样式化（不替换）。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_ll2_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_ll2_out.epub")
+        self._build(tmp, with_ncx=False)
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            stats = lib.beautify(tmp, out, css)
+            self.assertFalse(stats["toc_generated"])
+            self.assertEqual(stats["toc_replaced_linkless"], 0)
+            with zipfile.ZipFile(out) as zf:
+                opf = zf.read("OEBPS/content.opf").decode("utf-8")
+                plain = zf.read("OEBPS/part0003.xhtml").decode("utf-8")
+            self.assertIn('idref="t"', opf)          # 原条目保留
+            self.assertIn("mb-toc-page", plain)      # 仍被样式化
+            self.assertNotIn('class="mb-ch"', plain)
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_analyze_linkless_toc_not_counted_as_inbook(self):
+        """无链接目录页会被替换，analyze 不把它算作「书内已有目录」。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_ll3.epub")
+        self._build(tmp, with_ncx=True)
+        try:
+            a = lib.analyze_epub(tmp)
+            self.assertFalse(a["has_inbook_toc"])
+        finally:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+
+    def test_link_toc_still_kept(self):
+        """可点击的链接目录页不受影响：保留原页、不生成 mb-toc。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_ll4_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_ll4_out.epub")
+        link_toc = ('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>目录</title>'
+                    '</head><body>'
+                    + "".join('<p><a href="c1.xhtml">第%d章 标题</a></p>' % i
+                              for i in range(1, 13))
+                    + '</body></html>')
+        self._build(tmp, with_ncx=True, toc_html=link_toc)
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            stats = lib.beautify(tmp, out, css)
+            self.assertFalse(stats["toc_generated"])
+            self.assertEqual(stats["toc_replaced_linkless"], 0)
+            with zipfile.ZipFile(out) as zf:
+                opf = zf.read("OEBPS/content.opf").decode("utf-8")
+            self.assertIn('idref="t"', opf)
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)

--- a/tests/test_epub_beautify_core.py
+++ b/tests/test_epub_beautify_core.py
@@ -3373,6 +3373,123 @@ class TestLinklessTocReplacement(unittest.TestCase):
             if os.path.exists(tmp):
                 os.remove(tmp)
 
+    def test_toc_inserted_after_cover(self):
+        """无书内目录页时，生成的目录页挂在封面之后（不再顶到 spine 首位）。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_pos_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_pos_out.epub")
+        self._build_position_epub(tmp, front_files=("cover.xhtml",))
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            lib.beautify(tmp, out, css)
+            self.assertEqual(self._spine(out), ["f0", "mb-toc", "c1", "c2"])
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_toc_inserted_after_front_matter_block(self):
+        """封面 + 扉页 + 版权页：目录排在整段前置页之后。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_pos2_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_pos2_out.epub")
+        self._build_position_epub(
+            tmp, front_files=("cover.xhtml", "titlepage.xhtml", "banquan.xhtml"))
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            lib.beautify(tmp, out, css)
+            self.assertEqual(self._spine(out),
+                             ["f0", "f1", "f2", "mb-toc", "c1", "c2"])
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_toc_inserted_at_front_without_cover(self):
+        """无封面/前置页：维持原行为（spine 首位）。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_pos3_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_pos3_out.epub")
+        self._build_position_epub(tmp, front_files=())
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            lib.beautify(tmp, out, css)
+            self.assertEqual(self._spine(out), ["mb-toc", "c1", "c2"])
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_toc_inserted_after_guide_cover(self):
+        """文件名无 cover 特征时靠 guide reference type=cover 定位。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_pos4_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_pos4_out.epub")
+        self._build_position_epub(tmp, front_files=("p001.xhtml",),
+                                  guide_href="p001.xhtml")
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            lib.beautify(tmp, out, css)
+            self.assertEqual(self._spine(out), ["f0", "mb-toc", "c1", "c2"])
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_bare_title_first_file_not_anchor(self):
+        """裸 title.html 不在封面特征表内 → 不当前置页，目录仍排 spine 首位。"""
+        tmp = os.path.join(TESTS_DIR, "_tmp_pos5_src.epub")
+        out = os.path.join(TESTS_DIR, "_tmp_pos5_out.epub")
+        self._build_position_epub(tmp, front_files=("title.html",))
+        try:
+            css = get_preset_css("classic", use_system_fonts=True)
+            lib.beautify(tmp, out, css)
+            self.assertEqual(self._spine(out), ["mb-toc", "f0", "c1", "c2"])
+        finally:
+            for p in (tmp, out):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def _build_position_epub(self, path, front_files=("cover.xhtml",),
+                             guide_href=None):
+        """前置页 + 两章 + NCX；spine = 前置页 → c1 → c2。"""
+        manifest = "".join(
+            '<item id="f%d" href="%s" media-type="application/xhtml+xml"/>' % (i, f)
+            for i, f in enumerate(front_files))
+        manifest += (
+            '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="c2" href="c2.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>')
+        spine = "".join('<itemref idref="f%d"/>' % i
+                        for i in range(len(front_files)))
+        spine += '<itemref idref="c1"/><itemref idref="c2"/>'
+        guide = ('<guide><reference type="cover" href="%s"/></guide>' % guide_href
+                 if guide_href else '')
+        opf = (
+            '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            '<metadata><dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">'
+            '位置书</dc:title></metadata>'
+            '<manifest>%s</manifest><spine toc="ncx">%s</spine>%s</package>'
+        ) % (manifest, spine, guide)
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip",
+                        compress_type=zipfile.ZIP_STORED)
+            zf.writestr("META-INF/container.xml", CONTAINER)
+            zf.writestr("OEBPS/content.opf", opf)
+            for f in front_files:
+                zf.writestr("OEBPS/" + f,
+                            '<html xmlns="http://www.w3.org/1999/xhtml">'
+                            '<body><p>前置页。</p></body></html>')
+            zf.writestr("OEBPS/c1.xhtml",
+                        '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                        '<p>第一章 开端</p><p>正文。</p></body></html>')
+            zf.writestr("OEBPS/c2.xhtml",
+                        '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                        '<p>第二章 转折</p><p>正文。</p></body></html>')
+            zf.writestr("OEBPS/toc.ncx", self.NCX)
+
+    def _spine(self, out):
+        with zipfile.ZipFile(out) as zf:
+            opf = zf.read("OEBPS/content.opf").decode("utf-8")
+        return re.findall(r'<itemref[^>]*idref="([^"]+)"', opf)
+
     def test_link_toc_still_kept(self):
         """可点击的链接目录页不受影响：保留原页、不生成 mb-toc。"""
         tmp = os.path.join(TESTS_DIR, "_tmp_ll4_src.epub")

--- a/webserver/toolbox/epub_beautify.py
+++ b/webserver/toolbox/epub_beautify.py
@@ -4,8 +4,9 @@
 对指定书籍的 EPUB 格式执行无损美化（目录样式 / 章节名样式 / 字体排版），
 以「生成新书」模式入库，原书零改动：
 
-- **目录**：书内已有目录页则注入统一样式；无目录页时从 NCX/nav 生成
-  ``mb-toc.xhtml`` 目录页并注册进 OPF（spine 首条）；
+- **目录**：书内已有可点击目录页则注入统一样式；无目录页、或仅有 nav 语义页
+  / 无链接纯文本目录页时，从 NCX/nav 生成 ``mb-toc.xhtml`` 并注册进 OPF
+  （spine 首条或替换原目录页条目）；
 - **章节名**：三层识别章节标题（h1-h6 / 已知标题类 / 段落文本章节正则，
   正则移植自 hehetoshang/txt2epub-next，MIT），标记 ``mb-ch`` 统一样式
   （居中、分页、标题字体、留白），章首段顶格；
@@ -373,9 +374,10 @@ class EpubBeautifyTool(BaseTool):
                         dict(prog_common, stage="saving", new_book_id=new_book_id),
                     )
                     logging.info(
-                        "[EpubBeautifyTool] Beautified book_id=%d (headers=%d, vols=%d, splits=%d, toc=%s, rtl=%s, dialogs=%d, notes=%s/%s) -> new book_id=%d [uid:%d]",
+                        "[EpubBeautifyTool] Beautified book_id=%d (headers=%d, vols=%d, splits=%d, toc=%s/替换无链接%d, rtl=%s, dialogs=%d, notes=%s/%s) -> new book_id=%d [uid:%d]",
                         bid, stats.get("marked_headers", 0), stats.get("marked_volumes", 0),
                         stats.get("titles_split", 0), stats.get("toc_generated"),
+                        stats.get("toc_replaced_linkless", 0),
                         stats.get("page_progression") or "-", stats.get("dialogues_marked", 0),
                         stats.get("notes_refs", 0), stats.get("note_mark") or "-",
                         new_book_id, user_id,

--- a/webserver/toolbox/utils/epub_beautify_lib.py
+++ b/webserver/toolbox/utils/epub_beautify_lib.py
@@ -1814,6 +1814,50 @@ def _set_page_progression(opf_str: str, direction: str) -> str:
     return opf_str[:m.start()] + new_tag + opf_str[m.end():]
 
 
+# 封面/前置页文件名特征：生成目录页时据此把目录挂到封面之后。
+# 刻意不含 title / index / author 等裸名——它们会误伤正文首章（如 index.html）
+_COVER_FILE_RE = re.compile(
+    r'\b(?:cover|titlepage|title-page|half-title|halftitle|feiye|banquan|'
+    r'copyright|colophon|imprint)\b',
+    re.IGNORECASE,
+)
+
+
+def _toc_anchor_after_cover(ctx: OpfContext, entries: dict, opf_str: str) -> str:
+    """spine 开头连续「封面/前置页」中最后一个条目的 idref（无则 ''）。
+
+    生成目录页时的挂载锚点：目录排在封面（含扉页/版权等前置页）之后，而不是
+    顶到 spine 首位把封面挤到第二页。识别信号：EPUB2 ``guide`` 的
+    ``<reference type="cover">`` 指向页、manifest 条目 id 含 cover、文件名
+    命中 ``_COVER_FILE_RE``。只取**开头连续段**——正文首章一旦出现即停止，
+    避免把目录页插到正文中间。
+    """
+    guide_path = ''
+    m = re.search(r'<reference\b[^>]*type\s*=\s*["\']cover["\'][^>]*>', opf_str, re.I)
+    if m:
+        hm = re.search(r'href\s*=\s*["\']([^"\']+)["\']', m.group(0), re.I)
+        if hm:
+            guide_path = _snap_entry(entries, _resolve_zip(ctx.opf_dir, hm.group(1)))
+    anchor = ''
+    for idref, linear in ctx.spine:
+        if not linear:
+            continue
+        item = ctx.manifest.get(idref)
+        if not item:
+            break
+        path = _snap_entry(entries, _resolve_zip(ctx.opf_dir, item['href']))
+        base = path.rsplit('/', 1)[-1]
+        coverish = (
+            (bool(guide_path) and path == guide_path)
+            or bool(_COVER_FILE_RE.search(base))
+            or 'cover' in idref.lower()
+        )
+        if not coverish:
+            break
+        anchor = idref
+    return anchor
+
+
 def beautify(
     epub_path: str,
     out_path: str,
@@ -2025,10 +2069,17 @@ def beautify(
                         '', opf_str, count=1,
                     )
             else:
-                # 插入 spine 第一个 linear 条目之前
+                # 插入封面/前置页之后（识别不到封面时退回 spine 首位）
                 spine_m = re.search(r'<spine[^>]*>', opf_str)
                 if spine_m:
                     insert_at = spine_m.end()
+                    anchor_id = _toc_anchor_after_cover(ctx, entries, opf_str)
+                    if anchor_id:
+                        am = re.search(
+                            r'<itemref\b[^>]*idref=["\']%s["\'][^>]*/?>'
+                            % re.escape(anchor_id), opf_str)
+                        if am:
+                            insert_at = am.end()
                     opf_str = (
                         opf_str[:insert_at]
                         + '\n<itemref idref="%s" linear="yes"/>' % mb_id

--- a/webserver/toolbox/utils/epub_beautify_lib.py
+++ b/webserver/toolbox/utils/epub_beautify_lib.py
@@ -2,8 +2,10 @@
 """EPUB 美化核心库。
 
 对既有 EPUB 做无损美化（生成新书模式，原书零改动）：
-1. **目录**：书内已有目录页时仅样式化；无目录页时从 NCX/nav（EPUB3 nav）
-   生成 ``mb-toc.xhtml`` 目录页并注册进 OPF（manifest + spine，幂等）；
+1. **目录**：书内已有**可点击**目录页时仅样式化；无目录页、或仅有 nav 语义页
+   / 无链接纯文本目录页（两者保留无意义）时，从 NCX/nav（EPUB3 nav）生成
+   ``mb-toc.xhtml`` 目录页并注册进 OPF（manifest + spine，幂等），
+   nav 语义页与无链接页在 spine 中的条目被替换（原文件保留在包内）；
 2. **章节名**：正文条目三层识别章节标题（h1-h6 / 已知标题类 / 段落文本
    章节正则，后者移植自 hehetoshang/txt2epub-next，MIT）并标记 ``mb-ch``，
    章首段标记 ``data-mb-first``；
@@ -914,33 +916,37 @@ _TOC_RECHECK_BYTES = 64 * 1024
 def _classify_toc_entry(zip_path: str, raw: bytes) -> tuple:
     """单条目目录页判定（analyze 与 beautify 主流程共用，口径一致）。
 
-    文件名特征零解码；nav 语义看 8KB 头；头 8KB 内链接 ≥2 时以 64KB 片段
-    复核链接目录形态（``_looks_like_link_toc``），无链接时按目录标题门槛
-    复核纯文本列表形态（``_looks_like_plain_toc``），不再全量解码——此前
-    beautify 主流程只看头 2000/4000 字、analyze 用全量复核，两端口径不一，
-    长 ``<head>`` 的目录页会 preview 报「保留原书目录」而 run 误打章节标记。
+    文件名特征零解码；nav 语义看 8KB 头；无 nav 语义时按 8KB 头有无链接分流：
+    有链接以 64KB 片段复核链接目录形态（``_looks_like_link_toc``），无链接则
+    按目录标题门槛复核纯文本列表形态（``_looks_like_plain_toc``），不再全量
+    解码——此前 beautify 主流程只看头 2000/4000 字、analyze 用全量复核，两端
+    口径不一，长 ``<head>`` 的目录页会 preview 报「保留原书目录」而 run 误打
+    章节标记。
     :param raw: 条目原始字节（可为局部读取片段，≥ `_TOC_RECHECK_BYTES` 最佳）。
-    :return: (is_toc_doc, nav_semantic)
+    :return: (is_toc_doc, nav_semantic, linkless)
+        linkless=True 表示仅由纯文本列表形态判定（条目不可点击，保留无意义）
+        ——beautify 会像处理 nav 语义页一样用生成的链接目录页替换它。
     """
-    is_toc = bool(_TOC_FILE_RE.search(zip_path.rsplit('/', 1)[-1]))
-    nav_semantic = False
     head = _decode_head(raw)
-    if _has_nav_toc_semantics(head):
-        nav_semantic = True
-        is_toc = True
-    if not is_toc and len(re.findall(rb'<a\b', raw[:8192], re.IGNORECASE)) >= 2:
-        probe = _decode_head(raw, raw_n=_TOC_RECHECK_BYTES,
-                             out_n=_TOC_RECHECK_BYTES)
-        if _looks_like_link_toc(probe):
-            is_toc = True
-    elif not is_toc and _has_toc_title_text(head):
-        # 无链接纯文本目录页兜底：标题门槛在 8KB 头即可判定（常见书零成本
-        # 短路），命中才解码 64KB 复核章节行密度
-        probe = _decode_head(raw, raw_n=_TOC_RECHECK_BYTES,
-                             out_n=_TOC_RECHECK_BYTES)
-        if _looks_like_plain_toc(probe):
-            is_toc = True
-    return is_toc, nav_semantic
+    nav_semantic = bool(_has_nav_toc_semantics(head))
+    is_toc = bool(_TOC_FILE_RE.search(zip_path.rsplit('/', 1)[-1])) or nav_semantic
+    linkless = False
+    if not nav_semantic:
+        if len(re.findall(rb'<a\b', raw[:8192], re.IGNORECASE)) >= 2:
+            if not is_toc:
+                probe = _decode_head(raw, raw_n=_TOC_RECHECK_BYTES,
+                                     out_n=_TOC_RECHECK_BYTES)
+                if _looks_like_link_toc(probe):
+                    is_toc = True
+        elif _has_toc_title_text(head):
+            # 无链接纯文本目录页（含文件名已命中的 mulu.xhtml 等）：标题门槛
+            # 在 8KB 头即可判定（常见书零成本短路），命中才解码 64KB 复核行密度
+            probe = _decode_head(raw, raw_n=_TOC_RECHECK_BYTES,
+                                 out_n=_TOC_RECHECK_BYTES)
+            if _looks_like_plain_toc(probe):
+                is_toc = True
+                linkless = True
+    return is_toc, nav_semantic, linkless
 
 
 # 误打在目录页上的章节标记清理（修复旧版缺陷输出，见 _is_toc_doc）
@@ -1657,10 +1663,12 @@ def analyze_epub(epub_path: str, sample_limit: int = 20) -> dict:
             for t in text_entries:
                 if t not in entries:
                     continue
-                # 轻量嗅探（P1）：64KB 片段按需读，替代旧的全量解压复核
-                is_toc, is_nav = _classify_toc_entry(
+                # 轻量嗅探（P1）：64KB 片段按需读，替代旧的全量解压复核。
+                # 「书内已有目录」只认可点击的目录页：nav 语义页与无链接纯文本
+                # 目录页都会被生成的链接目录页替换，不计入（与 run 侧同口径）
+                is_toc, is_nav, is_linkless = _classify_toc_entry(
                     t, entries.head(t, _TOC_RECHECK_BYTES))
-                if is_toc and not is_nav:
+                if is_toc and not is_nav and not is_linkless:
                     has_inbook_toc = True
                     break
 
@@ -1842,9 +1850,9 @@ def beautify(
     :return: 统计 dict（marked_headers / marked_volumes / titles_split /
         toc_generated / toc_entries / injected_css / chapters / rtl /
         cleaned_leading / removed_empty / toc_excluded / toc_links_ok /
-        toc_links_total / dialogues_marked / notes_refs / notes_items /
-        notes_normalized / notes_wrapped / toc_titles_marked /
-        mark_guard_files）
+        toc_links_total / toc_replaced_linkless / dialogues_marked /
+        notes_refs / notes_items / notes_normalized / notes_wrapped /
+        toc_titles_marked / mark_guard_files）
     """
     if notes:
         validate_note_mark(note_mark)
@@ -1884,6 +1892,7 @@ def beautify(
     toc_excluded = 0
     toc_links_ok = 0
     toc_links_total = 0
+    toc_replaced_linkless = 0
 
     def _abs_with_anchor(base_dir, ref):
         """把目录条目引用解析为 zip 绝对路径（保留 #锚点）。"""
@@ -1928,17 +1937,25 @@ def beautify(
     # 仅看头 2000/4000 字，长 <head> 的目录页会漏判而误打章节标记
     toc_page_flags = {}
     nav_semantic_flags = {}
+    linkless_flags = {}
     for t in text_entries:
         if t not in entries:
             continue
-        is_toc, is_nav = _classify_toc_entry(t, entries[t])
+        is_toc, is_nav, is_linkless = _classify_toc_entry(t, entries[t])
         toc_page_flags[t] = is_toc
         nav_semantic_flags[t] = is_nav
+        linkless_flags[t] = is_linkless
     inbook_toc_paths = [t for t in text_entries if toc_page_flags.get(t)]
     # nav 语义目录页（内容含 <nav epub:type="toc">）：手机阅读器当目录数据源
-    # 特殊处理，spine 中无论 manifest 是否标 properties 都需替换为普通结构
+    # 特殊处理，spine 中无论 manifest 是否标 properties 都需替换为普通结构。
+    # 无链接纯文本目录页（linkless）条目不可点击，保留无意义——有 NCX/nav
+    # 数据时同样替换为生成的链接目录页；无数据源（toc_items 为空）则退回
+    # 仅样式化，至少不炸页。两类目标按 spine 顺序合并，替换后目录页占
+    # 原首个目标页的位置。
     nav_semantic_paths = [t for t in text_entries if nav_semantic_flags.get(t)]
-    nav_semantic_in_spine = bool(nav_semantic_paths)
+    toc_target_paths = [t for t in text_entries
+                        if nav_semantic_flags.get(t) or linkless_flags.get(t)]
+    replace_in_spine = bool(toc_target_paths)
     # spine 条目 zip 路径 → idref 映射（用于替换 itemref）。
     # 必须从 ctx.spine 逐项解析构建，不能 zip(text_entries, linear idrefs)——
     # spine 含非 XHTML 的 linear 条目（SVG 插图页 / 烂书直接塞图）或 manifest
@@ -1953,7 +1970,7 @@ def beautify(
         p = _snap_entry(entries, _resolve_zip(ctx.opf_dir, item['href']))
         path_to_idref.setdefault(p, idref)
 
-    if (not inbook_toc_paths or nav_semantic_in_spine) and toc_items:
+    if (not inbook_toc_paths or replace_in_spine) and toc_items:
         # 截断仅在显式传入 max_toc_entries 时发生（默认 None = 全量收录）
         truncated = (max_toc_entries is not None) and len(toc_items) > max_toc_entries
         if truncated:
@@ -1980,12 +1997,16 @@ def beautify(
                 % (mb_id, MB_TOC_NAME),
                 '目录页',
             )
-            # 找出 spine 中待替换的 idref：有 nav 语义时只替换 nav 页，否则为无目录时的插入
-            if nav_semantic_in_spine:
+            # 找出 spine 中待替换的 idref：nav 语义页 / 无链接纯文本目录页，
+            # 否则为无目录时的插入
+            if replace_in_spine:
                 replace_ids = [
-                    path_to_idref[t] for t in nav_semantic_paths
+                    path_to_idref[t] for t in toc_target_paths
                     if path_to_idref.get(t) and path_to_idref[t] != mb_id
                 ]
+                toc_replaced_linkless = sum(
+                    1 for t in toc_target_paths
+                    if linkless_flags.get(t) and path_to_idref.get(t))
             else:
                 replace_ids = []
             if replace_ids:
@@ -2192,6 +2213,7 @@ def beautify(
         'cleaned_leading': cleaned_leading,
         'removed_empty': removed_empty,
         'toc_excluded': toc_excluded,
+        'toc_replaced_linkless': toc_replaced_linkless,
         'toc_depth': toc_depth or 0,
         'toc_links_ok': toc_links_ok if toc_generated else 0,
         'toc_links_total': toc_links_total if toc_generated else 0,


### PR DESCRIPTION
承接 #74 的两项目录改进（3 文件 / 2 commit）。

- **无链接目录页 → 生成的链接目录替换**：无链接纯文本目录页条目不可点击，有 NCX/nav 数据时改用生成的 `mb-toc.xhtml` 替换其 spine 条目（原页保留在包内，无损），位置沿用原页位置；无数据源则退回仅样式化（仍不炸页）
- **生成的目录页挂到封面之后**：插入路径此前顶到 spine 首位、封面被挤到第二页；现识别封面/前置页（guide `reference type="cover"` / 条目 id 含 cover / 文件名 cover·titlepage·banquan·copyright 等），目录排在开头连续前置页之后；识别不到则维持原行为。替换路径仍沿用原页位置，不改变书籍原有阅读顺序

测试 187 → 197（`python tests/test_epub_beautify_core.py`），含 spine 位置断言、无数据源退回、链接目录不受影响等用例。
